### PR TITLE
fix(#8): resolve default branch dynamically

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -28,8 +28,8 @@ For personal projects, OSS, teams that embrace documentation. Knowledge goes dir
 For work environments where issues/PRs must stay clean. Knowledge lives in a **stacked knowledge branch** (`--log`) with its own PR targeting the feature branch.
 
 ```
-main
-  └── feature/auth-middleware            ← Clean PR to main
+<default-branch>
+  └── feature/auth-middleware            ← Clean PR to <default-branch>
         └── feature/auth-middleware--log  ← Knowledge PR targets feature branch
 ```
 
@@ -349,7 +349,10 @@ Also search knowledge graph if available: `/ork:memory search "#<issue-id>"`
 Delegate to `superpowers:using-git-worktrees` if isolation is needed, otherwise:
 
 ```bash
-git checkout main && git pull origin main
+# Resolve the repo default branch dynamically — never hardcode main/master
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+
+git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH
 git checkout -b issue/<ISSUE_NUMBER>-<brief-description>
 ```
 
@@ -555,7 +558,7 @@ Delegate to `ork:create-pr` (validation) or `superpowers:finishing-a-development
 
 ```bash
 ISSUE_NUMBER=<N>
-BASE_BRANCH=main
+BASE_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
 
 gh pr create --base $BASE_BRANCH \
   --title "<type>(#$ISSUE_NUMBER): Brief description" \
@@ -585,7 +588,7 @@ Closes #<ISSUE_NUMBER>
 ### Changes Made
 
 **Commits:**
-[list commits with `git log --oneline main..HEAD`]
+[list commits with `git log --oneline $BASE_BRANCH..HEAD`]
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Replace all hardcoded `main` references with dynamic default branch resolution via `gh repo view --json defaultBranchRef`. Repos using `master`, `develop`, or any other default branch now work correctly.

Closes #8

## Journey Timeline

### Initial Plan
Issue #8 identified that Phase 2 and Phase 5 hardcoded `main` as the base branch, breaking repos that use other default branch names.

### What We Discovered
- 4 locations total needed fixing (not just the 2 originally reported): Quiet Mode diagram, Phase 2 checkout, Phase 5 PR base, and the git log template in the PR body
- The Quiet Mode diagram at line 31 was illustrative, so we used a `<default-branch>` placeholder instead of a shell variable

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Resolution method | `gh repo view --json defaultBranchRef` | More reliable than `git symbolic-ref` which requires `origin/HEAD` to be set |
| Diagram treatment | `<default-branch>` placeholder | It's a visual diagram, not executable code |

### Changes Made

**Commits:**
- `be84472` fix(#8): resolve default branch dynamically instead of hardcoding main

## Testing

- [x] Verified no remaining hardcoded `main` references (excluding the "never hardcode main/master" comment)
- [x] All 4 locations updated: Quiet Mode diagram, Phase 2, Phase 5 BASE_BRANCH, PR template git log

---
*Captain's log — PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
