### PR TITLE
docs(#5): complete shell portability for branch commands

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -356,6 +356,15 @@ git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH
 git checkout -b issue/<ISSUE_NUMBER>-<brief-description>
 ```
 
+Portable note:
+- On PowerShell, break the chained commands into separate steps and use a different variable capture syntax:
+  ```powershell
+  $DEFAULT_BRANCH = gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+  git checkout $DEFAULT_BRANCH
+  git pull origin $DEFAULT_BRANCH
+  git checkout -b issue/<ISSUE_NUMBER>-<brief-description>
+  ```
+
 ### Step 3: Post timeline entry (Full Mode)
 
 ```bash
@@ -388,6 +397,9 @@ gh pr create --base <branch> \
 # Then switch back to the feature branch
 git checkout <branch>
 ```
+
+Portable note:
+- On PowerShell, use backtick (`` ` ``) for line continuation instead of `\`, or pass the PR body via `--body-file`.
 
 Post a comment on the `--log` PR:
 ```bash


### PR DESCRIPTION
## Summary

Adds PowerShell-safe portable notes to the two remaining Bash-specific branch command blocks: PHASE 2 branch setup (variable capture + `&&` chaining) and Quiet Mode `--log` branch creation (line continuation syntax).

Closes #5

## Journey Timeline

### Initial Plan
Issue #5 identified that shell portability guidance was improved but Bash-specific branch setup remained without portable alternatives.

### Changes Made
- Added PowerShell variant for `DEFAULT_BRANCH` capture and sequential checkout commands in PHASE 2
- Added portable note for line continuation in Quiet Mode `--log` PR creation

## Testing
- [x] Verified SKILL.md renders correctly
- [x] PowerShell syntax is valid

## Knowledge for Future Reference
The Shell Portability section provides the general principle; individual code blocks get inline "Portable note" callouts for platform-specific syntax differences.

---
*Captain's log — PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
