### PR TITLE
feat(#39): add contract-first shiplog templates

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -51,7 +51,7 @@ Assign AI model tiers to phases based on cognitive demand. Advisory only — nev
 
 **Routing prompt:** At phase transitions when the tier changes, suggest the model switch. For cross-tool switches, include the handoff location.
 
-**Context handoff:** When transitioning tiers, write a self-contained handoff comment. The golden rule: if a tier-3 model reading the handoff would need to make a judgment call, the handoff is not specific enough.
+**Context handoff:** When transitioning tiers, write a self-contained handoff comment. Treat lower-tier execution as a contract, not a goal: allowed files, forbidden changes, stop conditions, verification, return artifact, and decision budget should be explicit. The golden rule: if a tier-3 model reading the handoff would need to make a judgment call, the handoff is not specific enough.
 
 See `references/model-routing.md` for full configuration format, setup wizard, handoff template, and examples.
 
@@ -154,7 +154,7 @@ Key rules:
 
 1. **Run the brainstorm.** Delegate to `superpowers:brainstorming` or `ork:brainstorming`, or brainstorm inline for quick discussions.
 
-2. **Capture as GitHub Issue (Full Mode).** Use the issue template from `references/phase-templates.md`. The issue body should include: Context, Design Summary, Approach, Alternatives Considered, Tasks (with tier tags), and Open Questions.
+2. **Capture as GitHub Issue (Full Mode).** Use the issue template from `references/phase-templates.md`. The issue body should include: Context, Design Summary, Approach, Alternatives Considered, Tasks (with tier tags and contract fields), and Open Questions.
 
 3. **Quiet Mode: defer capture.** Do not create the `--log` PR yet — the feature branch does not exist until PHASE 2. Save the brainstorm content locally and use it as the opening entry when the `--log` PR is created in PHASE 2.
 
@@ -185,6 +185,7 @@ Key rules:
 3. **Post timeline entry.** Full Mode: comment on the issue. Quiet Mode: create `--log` branch + PR targeting the feature branch. See `references/phase-templates.md` for templates.
 
 4. **Load plan** if it exists. Delegate to `superpowers:executing-plans` or `ork:implement`.
+   For delegated or tier-3 work, the plan should define a contract: allowed files, forbidden changes, stop conditions, verification, return artifact, and decision budget.
 
 ---
 
@@ -212,7 +213,7 @@ Discovery made during work
 
 1. **Delegate the commit.** Use `ork:commit` > `commit-commands:commit` > manual `git commit`. Format: `<type>(#<issue-id>): <description>`.
 
-2. **Add context comment** for significant commits. Document the reasoning on the issue (Full Mode) or `--log` PR (Quiet Mode). See `references/phase-templates.md` for the commit context template.
+2. **Add context comment** for significant commits. Document the reasoning and verification on the issue (Full Mode) or `--log` PR (Quiet Mode). See `references/phase-templates.md` for the commit context template.
 
 **When to add context comments:** After significant functionality, unexpected discoveries, approach changes, or tricky bug fixes. NOT after trivial commits.
 

--- a/skills/shiplog/references/model-routing.md
+++ b/skills/shiplog/references/model-routing.md
@@ -162,6 +162,7 @@ Switch to <provider>. The handoff is on issue #<N>.
 ## Context Handoff Protocol
 
 When transitioning from a higher tier to a lower tier, the outgoing model MUST write a handoff comment on the issue (Full Mode) or `--log` PR (Quiet Mode).
+The receiving model should get a contract, not a goal. If a cheaper model must infer scope from tone, the handoff is underspecified.
 
 ### Handoff template
 
@@ -179,6 +180,14 @@ When transitioning from a higher tier to a lower tier, the outgoing model MUST w
 1. [Concrete action with file path]
 2. [Concrete action with file path]
 3. [Concrete action with file path]
+
+### Contract
+- **Allowed files:** `path/to/file.ts`, `path/to/other.ts`
+- **Must not change:** [files, APIs, behavior, or decisions that remain out of scope]
+- **Stop and ask if:** [condition that would require widening scope or making a judgment call]
+- **Verification required:** [tests, checks, or evidence that must exist before reporting done]
+- **Return artifact:** [diff summary, verification note, changed file list, blocker report]
+- **Decision budget:** `none` | `narrow` | `full`
 
 ### Files to touch
 - `path/to/file.ts` (create) — [what goes in it]
@@ -201,6 +210,9 @@ The skill detects which case applies by checking the **Provider** column in the 
 ### The golden rule
 
 > If a tier-3 model reading this handoff would need to make a judgment call, the handoff is not specific enough. Rewrite it until every decision is pre-made.
+
+For delegated execution, `Decision budget: none` should be the default.
+If the work really needs local judgment, narrow the allowed decision surface explicitly instead of implying it.
 
 ---
 

--- a/skills/shiplog/references/phase-templates.md
+++ b/skills/shiplog/references/phase-templates.md
@@ -33,25 +33,37 @@ gh issue create \
 
 Each task is self-contained. A tier-3 model should be able to execute any task
 using only the information in that task block, without reading the rest of this issue.
+When exact behavior matters, write a contract instead of relying on emphasis or tone.
 
 - [ ] **Task 1: [Short title]** `[tier-3]`
   - **What:** [1-2 sentences, exactly what to do — no ambiguity]
   - **Files:** `path/to/file.ts` (create|modify|delete)
+  - **Allowed to change:** [`path/to/file.ts`; specific symbols or sections if needed]
+  - **Must not change:** [files, APIs, behavior, or decisions that are out of scope]
+  - **Stop and ask if:** [condition that would require widening scope or making a product/architecture choice]
+  - **Verification:** [command, check, or evidence required before claiming completion]
+  - **Return artifact:** [diff, comment, checklist update, verification note, or exact file list]
+  - **Decision budget:** `none`
   - **Accept when:** [concrete, testable acceptance criteria]
   - **Context:** [any non-obvious background the implementer needs]
 
 - [ ] **Task 2: [Short title]** `[tier-1]`
   - **What:** [1-2 sentences]
   - **Files:** `path/to/file.ts`
+  - **Decision budget:** [what judgment this task is allowed to exercise]
   - **Accept when:** [criteria]
   - **Why tier-1:** [why this needs reasoning, e.g., "requires evaluating 3 API options"]
 
 Tier tag rules:
 - `[tier-3]` tasks MUST be executable without creative judgment.
-  Every decision is pre-made in the task description.
+  Every decision is pre-made in the task description and contract fields.
 - `[tier-1]` tasks require reasoning or trade-off evaluation.
   Include **Why tier-1** explaining what judgment is needed.
 - `[tier-2]` tasks need context awareness but not deep creativity.
+- If a task has safety-critical or review-critical steps, put them in
+  **Verification** or **Stop and ask if**, not in emphatic prose.
+- If completion needs to be checked later, define the **Return artifact**
+  explicitly so another human or agent can verify it.
 - The golden rule: if a tier-3 model would need to make a judgment call,
   the task is not specific enough. Rewrite it.
 
@@ -160,6 +172,7 @@ gh issue comment <ISSUE_NUMBER> --body "$(cat <<EOF
 **What:** $COMMIT_MSG
 
 **Why:** [1-2 sentences explaining the reasoning]
+**Verification:** [What was checked, what was deferred, or "Not run"]
 
 **Discovered:** [Anything unexpected, or "Nothing unexpected"]
 
@@ -182,6 +195,7 @@ $body = @"
 **What:** $commitMsg
 
 **Why:** [1-2 sentences explaining the reasoning]
+**Verification:** [What was checked, what was deferred, or "Not run"]
 
 **Discovered:** [Anything unexpected, or "Nothing unexpected"]
 


### PR DESCRIPTION
## Summary

This updates shiplog so lower-tier or delegated work is expressed as an execution contract instead of relying on stronger wording in prose.

Closes #39

## Journey Timeline

### Initial Plan
Add explicit contract fields to the issue-task and handoff templates so exact behavior is encoded in the workflow itself.

### What We Discovered
- The current templates already had the right intent, but they still left too much scope implied by narrative text.
- Commit-context comments benefit from a lightweight verification field because "done" should be checkable later.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Task enforcement | Add contract fields to issue tasks | Tier-3 work should not depend on tone for boundaries |
| Handoff shape | Add a Contract block to model-routing handoffs | Delegated execution should receive a contract, not a goal |
| Completion trace | Add verification to commit context comments | Later review should be able to inspect what was checked |

### Changes Made

**Commits:**
- 5c5c806 feat(#39): add contract-first task templates

## Testing

- [x] Reviewed the git diff for skills/shiplog/SKILL.md
- [x] Reviewed the git diff for skills/shiplog/references/phase-templates.md
- [x] Reviewed the git diff for skills/shiplog/references/model-routing.md
- [x] No runtime tests required for documentation/template-only changes

## Stacked PRs / Related

- Related to #16 delegation contracts
- Related to #22 verification evidence logging

## Knowledge for Future Reference

If shiplog needs a behavior to be reliable across humans and models, it should encode that behavior as a contract field, checklist item, schema, or verifier artifact instead of just increasing rhetorical emphasis.

---
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*