### PR TITLE
docs(#41): backfill shiplog review-finding fixes

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -180,6 +180,14 @@ Key rules:
    git worktree add ../$BRANCH -b $BRANCH origin/$DEFAULT_BRANCH
    cd ../$BRANCH
    ```
+   ```powershell
+   $defaultBranch = gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+   git fetch origin $defaultBranch
+   $branch = 'issue/<ISSUE_NUMBER>-<brief-description>'
+   git worktree add ../$branch -b $branch origin/$defaultBranch
+   Set-Location ../$branch
+   ```
+   See `references/shell-portability.md` for shell-specific notes.
    **Fallback (in-place checkout):** Only when the user explicitly requests no worktree.
 
 3. **Post timeline entry.** Full Mode: comment on the issue. Quiet Mode: create `--log` branch + PR targeting the feature branch. See `references/phase-templates.md` for templates.
@@ -307,7 +315,23 @@ This skill ORCHESTRATES. It never reimplements.
 | `git` | Branch, commit, diff, log | Pre-installed |
 | GitHub remote | Must be in a git repo with GitHub remote | — |
 
-All recommended skills are optional. See `references/phase-templates.md` for full skill list. Without them, shiplog falls back to direct `gh`/`git` commands.
+All recommended skills are optional. The current optional integrations are listed below. Without them, shiplog falls back to direct `gh`/`git` commands.
+
+### Recommended Skills
+
+| Skill | Plugin | What It Adds |
+|-------|--------|-------------|
+| `ork:commit` | OrchestKit | Conventional commits with validation |
+| `ork:create-pr` | OrchestKit | PR creation with parallel validation agents |
+| `ork:stacked-prs` | OrchestKit | Stacked PR mechanics and management |
+| `ork:issue-progress-tracking` | OrchestKit | Auto-checkbox updates from commits |
+| `ork:remember` / `ork:memory` | OrchestKit | Knowledge graph storage and retrieval |
+| `ork:brainstorming` | OrchestKit | Parallel agent brainstorming |
+| `superpowers:brainstorming` | Superpowers | Design-first brainstorming workflow |
+| `superpowers:using-git-worktrees` | Superpowers | Isolated workspace creation |
+| `superpowers:finishing-a-development-branch` | Superpowers | Post-implementation options |
+| `superpowers:writing-plans` | Superpowers | Structured plan documents |
+| `superpowers:executing-plans` | Superpowers | Plan execution with checkpoints |
 
 ### Codex agent identity
 

--- a/skills/shiplog/references/shell-portability.md
+++ b/skills/shiplog/references/shell-portability.md
@@ -42,3 +42,21 @@ Use the same pattern for `gh issue create`, `gh pr create`, and `gh pr comment`.
 - In an expandable string or here-string, `` `$var `` escapes interpolation and posts the literal text `$var`.
 - Use `` ``$var`` `` when you want markdown backticks around the interpolated value.
 - If in doubt, avoid markdown code spans and post values as plain text.
+
+## Worktree branch setup
+
+```bash
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+git fetch origin $DEFAULT_BRANCH
+BRANCH=issue/<ISSUE_NUMBER>-<brief-description>
+git worktree add ../$BRANCH -b $BRANCH origin/$DEFAULT_BRANCH
+cd ../$BRANCH
+```
+
+```powershell
+$defaultBranch = gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+git fetch origin $defaultBranch
+$branch = 'issue/<ISSUE_NUMBER>-<brief-description>'
+git worktree add ../$branch -b $branch origin/$defaultBranch
+Set-Location ../$branch
+```


### PR DESCRIPTION
## Summary

Backfills the review-finding documentation fixes under shiplog so the changes are tracked through an issue branch and PR instead of remaining as local edits on master. It also restores the missing recommended-skills guidance and adds a PowerShell-safe worktree setup example.

Closes #41

## Journey Timeline

### Initial Plan
The immediate task was to fix the two review findings: the Bash-only default worktree example and the broken recommended-skills reference left by the SKILL split.

### What We Discovered
- The docs fix was made locally before shiplog was activated, so the work had to be backfilled onto a dedicated issue branch.
- That workflow miss is its own process problem, now tracked in #42.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| How to preserve the existing edits | Move them from master onto issue/41-backfill-shiplog-review-fixes | Keeps the resulting history compliant without redoing the content work |
| Where to restore the skills list | Put it back in SKILL.md Requirements | Removes the broken pointer and keeps the integration guidance adjacent to workflow requirements |
| How to address the process miss | Open #42 as a separate discovery issue | The workflow failure needs its own durable follow-up |

### Changes Made

**Commits:**
- 1038f70 docs(#41): backfill shiplog review-finding fixes

## Testing

- [x] Verified the touched docs now contain both Bash and PowerShell worktree setup examples.
- [x] Verified the recommended skills section is present again in skills/shiplog/SKILL.md.
- [x] No automated tests were run because this is documentation-only.

## Stacked PRs / Related

- #42

## Knowledge for Future Reference

If shiplog is activated late, the safest recovery is to create the tracking issue immediately, move the existing changes onto an issue-scoped branch, and log the retroactive session start and commit context instead of pretending the work began on the right branch.

---
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*