### PR TITLE
feat(#19): add verification profiles and semantic-stability gates

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -217,6 +217,8 @@ Discovery made during work
 
 **When to add context comments:** After significant functionality, unexpected discoveries, approach changes, or tricky bug fixes. NOT after trivial commits.
 
+**Verification profiles:** When a verification profile is active, include verification evidence in commit context and PR timeline. See `references/verification-profiles.md` for profile configuration, behavior-spec protocol, and evidence requirements.
+
 ---
 
 ## PHASE 5: PR-as-Timeline

--- a/skills/shiplog/references/phase-templates.md
+++ b/skills/shiplog/references/phase-templates.md
@@ -173,6 +173,11 @@ gh issue comment <ISSUE_NUMBER> --body "$(cat <<EOF
 
 **Why:** [1-2 sentences explaining the reasoning]
 **Verification:** [What was checked, what was deferred, or "Not run"]
+[If verification profile active]:
+- **Profile:** [active profile names]
+- **Scenarios:** [added N, changed M, existing passed K]
+- **Tests:** [added N, changed M, all passing]
+- **Deferred:** [anything intentionally skipped, with reason]
 
 **Discovered:** [Anything unexpected, or "Nothing unexpected"]
 
@@ -196,6 +201,11 @@ $body = @"
 
 **Why:** [1-2 sentences explaining the reasoning]
 **Verification:** [What was checked, what was deferred, or "Not run"]
+[If verification profile active]:
+- **Profile:** [active profile names]
+- **Scenarios:** [added N, changed M, existing passed K]
+- **Tests:** [added N, changed M, all passing]
+- **Deferred:** [anything intentionally skipped, with reason]
 
 **Discovered:** [Anything unexpected, or "Nothing unexpected"]
 
@@ -244,8 +254,14 @@ Closes #<ISSUE_NUMBER>
 
 ## Testing
 
+[If verification profile active]:
+**Verification profile:** [profile names]
+
 - [x] [What was tested and how]
 - [x] All existing tests pass
+- [x] [Verification-profile-specific checks, e.g., "Fail-first confirmed", "No existing scenarios modified"]
+
+**Verification summary:** [scenarios added/changed, tests added/changed, deferred items]
 
 ## Stacked PRs / Related
 

--- a/skills/shiplog/references/verification-profiles.md
+++ b/skills/shiplog/references/verification-profiles.md
@@ -1,0 +1,326 @@
+# Verification Profiles
+
+Configurable testing and semantic-stability profiles for shiplog. Verification is not "run tests" — it is semantic-stability pressure that makes behavior drift expensive enough to catch.
+
+---
+
+## Design Principles
+
+- **Shiplog defines policy, not tooling.** Profiles say when verification is required and how evidence is logged. Language/framework skills provide the actual test commands.
+- **Behavior drift must be visible.** New features must not silently weaken old tests. Changes to existing scenarios require explicit acknowledgment.
+- **Delegated agents inherit verification pressure.** A tier-3 agent cannot bypass verification by taking the path of least resistance — the profile travels with the task contract.
+- **Graceful degradation.** Projects without profiles still work. The default profile is `none` (no enforcement, no logging). Profiles add rigor when opted in.
+
+---
+
+## 1. Profile Taxonomy
+
+| Profile | Purpose | Default enforcement |
+|---------|---------|---------------------|
+| `none` | No verification requirements | silent |
+| `behavior-spec` | Acceptance scenarios for new/changed behavior | per-issue opt-in |
+| `red-green` | Fail-first unit tests for changed behavior | per-issue opt-in |
+| `structural` | Structural quality analysis on changed modules | per-issue opt-in |
+| `mutation` | Differential mutation testing on changed modules | strict-profile opt-in |
+
+Profiles are composable. A project or issue can activate multiple profiles simultaneously (e.g., `behavior-spec` + `red-green`).
+
+### Scope boundary
+
+Profiles govern the **evidence policy** — what must be checked and what must be recorded. They do not:
+
+- Prescribe a specific test framework or runner.
+- Replace language-specific testing skills (TDD, pytest, vitest, etc.).
+- Block workflow when the required tool is not installed — instead, log the gap as deferred verification.
+
+---
+
+## 2. Configuration and Resolution
+
+### Config location
+
+Verification profiles are configured in `.shiplog/verification.md` at the project root.
+
+### Config format
+
+```markdown
+# Verification Profiles
+
+## Default Profile
+behavior-spec, red-green
+
+## Profile Settings
+
+### behavior-spec
+- scenarios_required: true
+- ask_before_changing_existing: true
+- fail_first_evidence: true
+
+### red-green
+- fail_first_evidence: true
+
+### structural
+- threshold: crap <= 8
+- on_violation: refactor-before-proceed
+
+### mutation
+- mode: differential
+- max_workers: 3
+- on_survivors: cover-and-kill
+```
+
+### Resolution order
+
+```
+Per-task contract "Verification" field
+  > Per-issue ## Verification Profile section
+    > .shiplog/verification.md default
+      > Built-in default (none)
+        > Silent (no enforcement)
+```
+
+Each level can **tighten** the parent but not relax it. A per-issue override can add `mutation` to a project that defaults to `behavior-spec`, but cannot remove `behavior-spec` from an issue where the project requires it.
+
+### Per-issue override
+
+Add a `## Verification Profile` section to the issue body:
+
+```markdown
+## Verification Profile
+behavior-spec, red-green, structural
+
+### Overrides
+- structural.threshold: crap <= 5
+- mutation: opt-in (only for auth module)
+```
+
+### Per-task override
+
+In the task contract (see phase-templates.md), the **Verification** field specifies what the implementer must check. This is the most granular level — it tells the agent exactly what to run and what evidence to produce.
+
+### Surfacing during handoffs
+
+When a verification profile is active, handoff comments (see model-routing.md) SHOULD include the active profile so the receiving agent knows what verification is expected:
+
+```markdown
+### Verification
+- **Active profile:** behavior-spec, red-green
+- **What to run:** [specific commands or checks]
+- **Evidence required:** [what to log in the commit context]
+```
+
+---
+
+## 3. Behavior-Spec Protocol
+
+The `behavior-spec` profile requires acceptance scenarios for new or changed behavior before implementation begins.
+
+### Scenario lifecycle
+
+```
+1. Write scenarios    — describe expected behavior in plain language
+2. Confirm failure    — verify the scenario does not pass yet (fail-first)
+3. Implement          — make the scenarios pass
+4. Record evidence    — log which scenarios were added/changed/passed
+```
+
+### Scenario-change rules
+
+| Situation | Required action |
+|-----------|----------------|
+| New behavior | Write new acceptance scenarios before implementation |
+| Changed behavior | Identify affected existing scenarios first |
+| Modifying existing scenarios | Ask before changing — document why the old expectation is wrong |
+| Removing scenarios | Escalate — removing a scenario weakens the safety net |
+
+**The ask-before-changing rule** applies when an existing scenario needs modification. The agent must flag the change to the user (or higher-tier model) and document the reason. This prevents silent behavior redefinition.
+
+### Fail-first evidence
+
+When `fail_first_evidence: true`:
+
+1. Run the new or changed scenario before implementation.
+2. Confirm it fails for the expected reason.
+3. Record the failure output as evidence (in the commit context or issue timeline).
+4. Implement until the scenario passes.
+
+Fail-first confirmation is part of the verification evidence, not a debugging step. It proves the scenario is testing the right thing.
+
+### When scenarios are not practical
+
+Some changes (documentation-only, config changes, template updates) may not have testable behavior. In this case:
+
+- Log `Verification: behavior-spec — not applicable (docs-only change)` in the commit context.
+- The profile does not block — it just requires the exemption to be explicit.
+
+---
+
+## 4. Evidence in Artifacts
+
+When a verification profile is active, shiplog artifacts MUST record what verification was performed.
+
+### Commit-context evidence
+
+Add to the Phase 4 commit context comment:
+
+```markdown
+**Verification:**
+- **Profile:** behavior-spec, red-green
+- **Scenarios:** [added N, changed M, existing passed K]
+- **Tests:** [added N, changed M, all passing]
+- **Deferred:** [anything intentionally skipped, with reason]
+```
+
+When no profile is active, the existing `**Verification:** [What was checked, what was deferred, or "Not run"]` field from the commit context template is sufficient.
+
+### PR-timeline evidence
+
+Add to the Phase 5 PR timeline Testing section:
+
+```markdown
+## Testing
+
+**Verification profile:** behavior-spec, red-green
+
+- [x] Acceptance scenarios added for [new behavior]
+- [x] Fail-first confirmed before implementation
+- [x] All new tests passing
+- [x] All existing tests passing (no scenarios modified)
+- [ ] Structural analysis: deferred (no structural profile active)
+
+**Verification summary:**
+- Scenarios added: N
+- Tests added: N
+- Tests modified: M (reason: [why])
+- Existing scenarios changed: 0
+```
+
+### What to capture
+
+| Evidence type | When to log | Where |
+|---------------|-------------|-------|
+| Active profile | Every commit context, every PR | Commit comment, PR body |
+| Scenarios added/changed | When behavior-spec is active | Commit comment |
+| Fail-first output | When fail_first_evidence is true | Commit comment or issue timeline |
+| Test results summary | Every commit with test changes | Commit comment |
+| Existing scenarios modified | Always — this is a change signal | Commit comment + issue timeline |
+| Deferred verification | When something was intentionally skipped | Commit comment, PR body |
+| Structural analysis results | When structural profile is active | PR body |
+| Mutation results | When mutation profile is active | PR body |
+
+### Recording modifications to existing tests
+
+When existing tests or scenarios are modified, the evidence must explain why:
+
+```markdown
+**Existing scenarios changed:** 1
+- `test_auth_token_expiry`: updated expected TTL from 3600 to 7200 — requirement changed per #42
+```
+
+This makes behavior drift traceable. If a reviewer sees modified scenarios without explanation, that is a review finding.
+
+---
+
+## 5. Structural and Mutation Gates
+
+### Structural analysis
+
+The `structural` profile runs quality analysis on changed modules.
+
+**Changed module identification:** A module is "changed" if any file in its directory tree was modified in the current branch compared to the base branch.
+
+**Threshold configuration:**
+
+```markdown
+### structural
+- threshold: crap <= 8
+- analyzer: [tool-agnostic — the language skill provides the command]
+- on_violation: refactor-before-proceed | warn | log
+```
+
+| `on_violation` | Behavior |
+|----------------|----------|
+| `refactor-before-proceed` | Agent must reduce complexity before continuing |
+| `warn` | Log the violation in the commit context, continue |
+| `log` | Record silently in verification evidence |
+
+**Default:** `warn` — violations are visible but do not block progress.
+
+### Mutation testing
+
+The `mutation` profile runs differential mutation testing on changed modules.
+
+**Differential scope:** Only mutate lines that were added or modified in the current branch. This keeps mutation cost proportional to the change size.
+
+**Configuration:**
+
+```markdown
+### mutation
+- mode: differential | full
+- max_workers: 3
+- batch_size: 1 module at a time
+- on_survivors: cover-and-kill | warn | log
+```
+
+| Field | Description |
+|-------|-------------|
+| `mode` | `differential` mutates only changed lines; `full` mutates the entire changed module |
+| `max_workers` | Maximum parallel mutation processes |
+| `batch_size` | How many modules to mutate at once (default: 1 — sequential) |
+| `on_survivors` | What to do when mutations survive |
+
+| `on_survivors` | Behavior |
+|----------------|----------|
+| `cover-and-kill` | Agent must write tests to kill surviving mutants before continuing |
+| `warn` | Log survivors in commit context, continue |
+| `log` | Record silently in verification evidence |
+
+**Default:** `warn`.
+
+### Mutation opt-in rules
+
+- Mutation is **never** the default profile. It must be explicitly activated per-project or per-issue.
+- `mode: differential` is the recommended starting point — full-module mutation is expensive.
+- Mutation results appear in the PR body, not individual commit comments (too noisy per-commit).
+
+### Batching guidance
+
+When multiple modules are changed:
+
+1. Process one module at a time (default `batch_size: 1`).
+2. Run structural analysis first, mutation second.
+3. If structural violations exist, resolve them before running mutation (cleaner code mutates more meaningfully).
+4. Log per-module results in the PR verification summary.
+
+```markdown
+**Mutation summary:**
+| Module | Mutants | Killed | Survived | Coverage |
+|--------|---------|--------|----------|----------|
+| auth/  | 24      | 22     | 2        | 91.7%    |
+| api/   | 18      | 18     | 0        | 100%     |
+```
+
+---
+
+## Integration Points
+
+### With contract fields (phase-templates.md)
+
+Task contracts should reference the active profile in the **Verification** field:
+
+```markdown
+- **Verification:** Run behavior-spec scenarios + red-green tests for changed auth module. Profile: `behavior-spec, red-green`. Evidence: scenario count, fail-first log, test results.
+```
+
+### With delegation (model-routing.md)
+
+Delegated agents inherit the active verification profile. The handoff contract must state:
+- Which profile is active
+- What the agent must run
+- What evidence to produce in the return artifact
+
+A delegated agent MUST NOT silently weaken existing tests or scenarios. If a test change is needed, the agent should stop and escalate per the behavior-spec scenario-change rules.
+
+### With artifact envelopes (artifact-envelopes.md)
+
+Verification evidence artifacts should carry an envelope with `kind: verification` and `profile: <name>` so retrieval can quickly find what was verified.


### PR DESCRIPTION
## Summary

Adds configurable verification profiles so testing acts as semantic-stability pressure — behavior drift becomes expensive enough to catch, delegated agents inherit verification requirements, and evidence is recorded in commit and PR artifacts.

Closes #19, closes #20, closes #21, closes #22, closes #23

## Journey Timeline

### Initial Plan
Create a single reference document covering the full verification profile system (taxonomy, config, behavior-spec, evidence, gates) with pointers in SKILL.md and additions to phase-templates.md.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Config location | `.shiplog/verification.md` | Follows the `.shiplog/routing.md` pattern for project config |
| Resolution order | task > issue > project > default > silent | Same resolution pattern as model routing — consistent |
| Default profile | `none` | Graceful degradation — profiles add rigor when opted in |
| Mutation opt-in | Never default, always explicit | Mutation is expensive — must be a deliberate choice |
| Scenario-change rule | Ask before modifying existing scenarios | Prevents silent behavior redefinition |
| Tighten-only override | Lower levels can tighten but not relax | Safety net cannot be weakened by a sub-task |

### Evidence Table

| Issue | Satisfied by | Section |
|-------|-------------|---------|
| #19 (parent: profile concept) | Profile taxonomy, scope boundary, design principles | Intro + §1 |
| #20 (config & resolution) | Config format, resolution order, per-issue overrides | §2 |
| #21 (behavior-spec protocol) | Scenario lifecycle, scenario-change rules, fail-first evidence | §3 |
| #22 (evidence in artifacts) | Verification fields in commit-context and PR-timeline templates | §4 + phase-templates.md |
| #23 (structural & mutation gates) | Threshold config, mutation opt-in rules, batching guidance | §5 |

### Changes Made

**Commits:**
- 521118b feat(#19): add verification profiles and semantic-stability gates

**Files:**
- `skills/shiplog/references/verification-profiles.md` (created) — full verification profile specification
- `skills/shiplog/SKILL.md` (modified) — added verification-profiles pointer in Phase 4
- `skills/shiplog/references/phase-templates.md` (modified) — added verification evidence fields to commit context and PR timeline templates

## Testing

- [x] SKILL.md stays at 319 lines (under 400 limit)
- [x] No broken cross-references between SKILL.md and reference files
- [x] Each closed issue maps to a specific section in verification-profiles.md
- [ ] **Requires cross-model review before merge**

## Knowledge for Future Reference

The tighten-only resolution rule (lower levels cannot relax the parent profile) is a key design choice. It means a per-task contract can add `mutation` to `behavior-spec`, but cannot drop `behavior-spec` if the project requires it.

---
*Captain's log — PR timeline by [shiplog](https://github.com/devallibus/shiplog)*

**Authored by Claude Opus 4.6 (Claude Code). Requires review from a different model before merge.**