### PR TITLE
docs(#59): add operational retrieval guidance to review target selection

### DIFF
--- a/skills/shiplog/references/closure-and-review.md
+++ b/skills/shiplog/references/closure-and-review.md
@@ -143,6 +143,8 @@ When asked to review PRs, whether one PR or many (e.g., "review PRs", "check for
    > "All open PRs were last touched by [model]. Cross-model review requires a different model. Would you like me to review anyway as an audit trail (non-gate-satisfying)?"
 6. Only proceed with self-authored PR review if the user explicitly confirms after the reminder. Mark such reviews as `self-review` per Section 4 audit trail rules.
 
+**Where to find review artifacts:** Shiplog review sign-offs are posted as issue/PR comments, not formal GitHub review events (see §4 GitHub API constraint). When checking for existing reviews, search the PR body plus issue/PR comments for `Reviewed-by:` and `Disposition:` lines. Do not rely on the formal reviews API endpoint alone — it will miss most AI-operated reviews.
+
 **What counts as "last touched":** The most recent signed shiplog artifact you can verify on either side: (a) the newest author-side `Authored-by:` artifact associated with the work, or (b) the most recent review `Reviewed-by:` sign-off. Do not treat raw Git commit metadata as model provenance; shiplog authorship lives in signed artifacts, not the commit object. If the branch moved after the last visible signed author artifact and the responsible model is unclear, treat authorship as unknown and do not claim a gate-satisfying same-model review.
 
 ---


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 59
branch: issue/59-review-artifact-retrieval
status: resolved
updated_at: 2026-03-14T19:30:32.8591012+01:00
-->

## Summary

Add an operational retrieval note to the review target selection section so agents know where signed shiplog review artifacts actually live. This closes the gap exposed during the PR #56 / PR #54 review flow, where checking the formal reviews API alone missed existing signed comment reviews.

Closes #59

## Journey Timeline

### Initial Plan
Apply a minimal doc-only fix in `skills/shiplog/references/closure-and-review.md` without rewriting the existing review protocol.

### What We Discovered
- The issue branch initially came up on a stale local `master` and had to be fast-forwarded to `origin/master` before editing.
- The missing guidance belongs between the step list and the "What counts as last touched" paragraph, exactly as described in #59.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Retrieval guidance placement | Insert after steps 1-6, before "last touched" | Keeps the operational note adjacent to the review-selection workflow without changing the rules themselves |
| Artifact lookup wording | Point agents to the PR body plus issue/PR comments for `Reviewed-by:` and `Disposition:` lines | That matches the signed-comment review model already defined later in the file |

### Changes Made

**Commits:**
- `de8797d` docs(#59): add review artifact retrieval guidance

## Testing

- [x] Re-read the modified section to confirm the note sits in the intended location
- [x] Verified the note points to signed comments rather than the formal reviews API
- [x] Confirmed the rest of the review protocol remained unchanged

## Stacked PRs / Related

- Related to PR #54 incident analysis referenced in issue #59

## Knowledge for Future Reference

When shiplog defines a signed artifact format, the operational retrieval path needs to be documented near the workflow that depends on it. Stating only the sign-off schema is not enough.

---
Authored-by: openai/gpt-5 (codex)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
