### PR TITLE
docs(#51): wire signing into phase instructions

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -158,7 +158,7 @@ Key rules:
 
 1. **Run the brainstorm.** Delegate to `superpowers:brainstorming` or `ork:brainstorming`, or brainstorm inline for quick discussions.
 
-2. **Capture as GitHub Issue (Full Mode).** Use the issue template from `references/phase-templates.md`. The issue body should include: Context, Design Summary, Approach, Alternatives Considered, Tasks (with tier tags and contract fields), and Open Questions.
+2. **Capture as GitHub Issue (Full Mode).** Use the issue template from `references/phase-templates.md`. The issue body should include: Context, Design Summary, Approach, Alternatives Considered, Tasks (with tier tags and contract fields), and Open Questions. Sign the issue body per [Agent identity signing](#agent-identity-signing).
 
 3. **Quiet Mode: defer capture.** Do not create the `--log` PR yet — the feature branch does not exist until PHASE 2. Save the brainstorm content locally and use it as the opening entry when the `--log` PR is created in PHASE 2.
 
@@ -194,7 +194,7 @@ Key rules:
    See `references/shell-portability.md` for shell-specific notes.
    **Fallback (in-place checkout):** Only when the user explicitly requests no worktree.
 
-3. **Post timeline entry.** Full Mode: comment on the issue. Quiet Mode: create `--log` branch + PR targeting the feature branch. See `references/phase-templates.md` for templates.
+3. **Post timeline entry.** Full Mode: comment on the issue. Quiet Mode: create `--log` branch + PR targeting the feature branch. See `references/phase-templates.md` for templates. Sign the posted artifact per [Agent identity signing](#agent-identity-signing).
 
 4. **Load plan** if it exists. Delegate to `superpowers:executing-plans` or `ork:implement`.
    For delegated or tier-3 work, the plan should define a contract: allowed files, forbidden changes, stop conditions, verification, return artifact, and decision budget.
@@ -214,9 +214,9 @@ Discovery made during work
   +-- Refactoring opportunity?             -> Create issue tagged "refactor"
 ```
 
-**Phase 3a (stack a prerequisite):** Commit current progress. Create a new issue first (so the ID exists), then create the stacked branch. Cross-reference on the parent issue. See `references/phase-templates.md` for the discovery issue template.
+**Phase 3a (stack a prerequisite):** Commit current progress. Create a new issue first (so the ID exists), then create the stacked branch. Cross-reference on the parent issue. See `references/phase-templates.md` for the discovery issue template. Sign both the discovery issue and the parent cross-reference comment per [Agent identity signing](#agent-identity-signing).
 
-**Phase 3b (independent discovery):** Create new issue (same template without "blocks parent"). Add timeline comment. Continue current work.
+**Phase 3b (independent discovery):** Create new issue (same template without "blocks parent"). Add timeline comment. Continue current work. Sign each posted artifact per [Agent identity signing](#agent-identity-signing).
 
 ---
 
@@ -226,7 +226,7 @@ Discovery made during work
 
 1. **Delegate the commit.** Use `ork:commit` > `commit-commands:commit` > manual `git commit`. Format: `<type>(#<issue-id>): <description>`.
 
-2. **Add context comment** for significant commits. Document the reasoning and verification on the issue (Full Mode) or `--log` PR (Quiet Mode). See `references/phase-templates.md` for the commit context template.
+2. **Add context comment** for significant commits. Document the reasoning and verification on the issue (Full Mode) or `--log` PR (Quiet Mode). See `references/phase-templates.md` for the commit context template. Sign the comment per [Agent identity signing](#agent-identity-signing).
 
 **When to add context comments:** After significant functionality, unexpected discoveries, approach changes, or tricky bug fixes. NOT after trivial commits.
 
@@ -240,11 +240,11 @@ Discovery made during work
 
 1. **Pre-PR checks.** Delegate to `ork:create-pr` or `superpowers:finishing-a-development-branch`.
 
-2. **Create PR (Full Mode).** Use the PR timeline template from `references/phase-templates.md`. Body includes: Summary, `Closes #<N>`, Journey Timeline, Key Decisions, Changes, Testing, and Knowledge for Future Reference.
+2. **Create PR (Full Mode).** Use the PR timeline template from `references/phase-templates.md`. Body includes: Summary, `Closes #<N>`, Journey Timeline, Key Decisions, Changes, Testing, and Knowledge for Future Reference. Sign the PR body per [Agent identity signing](#agent-identity-signing).
 
-3. **Quiet Mode.** Create a clean feature PR (no shiplog content). Add a final summary comment to the `--log` PR.
+3. **Quiet Mode.** Create a clean feature PR (no shiplog content). Add a final summary comment to the `--log` PR. Sign the summary comment per [Agent identity signing](#agent-identity-signing).
 
-4. **Review gate.** Every PR requires cross-model review before merge. See `references/closure-and-review.md` for the review protocol, sign-off format, and merge authorization rules.
+4. **Review gate.** Every PR requires cross-model review before merge. See `references/closure-and-review.md` for the review protocol, sign-off format, and merge authorization rules. Sign every review artifact per [Agent identity signing](#agent-identity-signing).
 
 5. **Link and store.** PR body includes `Closes #<issue>`. Store key learning in knowledge graph.
 
@@ -265,7 +265,7 @@ Discovery made during work
 
 **Routing:** tier-3 (fast).
 
-Add timeline comments when: starting a new session, changing approach, finding something unexpected, completing a milestone, or getting blocked.
+Add timeline comments when: starting a new session, changing approach, finding something unexpected, completing a milestone, or getting blocked. Sign each timeline comment per [Agent identity signing](#agent-identity-signing).
 
 See `references/phase-templates.md` for the comment format. Comment types: `session-start`, `session-resume`, `milestone`, `discovery`, `approach-change`, `blocker`, `session-end`.
 


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 51
branch: issue/51-wire-signing-instructions
status: resolved
updated_at: 2026-03-14T19:33:21.8061933+01:00
-->

## Summary

Wire explicit signing reminders into the artifact-producing phase steps in `SKILL.md` so agents are told to sign issues, comments, PR bodies, and review artifacts at the point of action. The canonical signature grammar stays centralized in the existing Agent identity signing section.

Closes #51

## Journey Timeline

### Initial Plan
Apply a narrow SKILL.md edit that adds one-line signing reminders to the relevant phases without duplicating the signature grammar.

### What We Discovered
- The existing global signing rule was already correct; the gap was purely operational wiring at the phase action sites.
- Phase 5 needed coverage both for PR bodies and for review artifacts, not just the PR creation step.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Signing guidance placement | Add short reminders directly to artifact-producing steps | Keeps the requirement visible when agents are actually composing artifacts |
| Signature grammar reuse | Link back to the Agent identity signing section | Avoids divergence between the phase text and the canonical grammar |

### Changes Made

**Commits:**
- `16aaf1a` docs(#51): wire signing into phase instructions

## Testing

- [x] Re-read the Phase 1, 2, 3, 4, 5, and 7 sections after the patch
- [x] Confirmed each relevant phase now references the existing signing section
- [x] Confirmed no duplicate signature grammar was introduced

## Stacked PRs / Related

- None

## Knowledge for Future Reference

Global protocol rules are easy to miss when the action happens several sections away. If shiplog depends on a requirement at artifact creation time, the phase step should point to it explicitly.

---
Authored-by: openai/gpt-5 (codex)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
