### PR TITLE
docs(#58): require source verification in phase 1

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -159,6 +159,11 @@ Key rules:
 1. **Run the brainstorm.** Delegate to `superpowers:brainstorming` or `ork:brainstorming`, or brainstorm inline for quick discussions.
 
 2. **Capture as GitHub Issue (Full Mode).** Use the issue template from `references/phase-templates.md`. The issue body should include: Context, Design Summary, Approach, Alternatives Considered, Tasks (with tier tags and contract fields), and Open Questions. Sign the issue body per [Agent identity signing](#agent-identity-signing).
+   Before writing the final issue body, classify factual claims:
+   - **Internal claims** about this repository's code, tests, configuration, or committed docs can be verified from the repo itself. The codebase is the source of truth.
+   - **External claims** about third-party tools, URLs, APIs, platform capabilities, pricing, distribution channels, or ecosystem behavior must be verified against primary sources before they are stated as facts.
+   - If an external claim cannot be verified yet, keep it explicitly marked as `[unverified]` and treat it as a hypothesis, not settled input. Do not turn an unverified claim into a task requirement, acceptance criterion, or architectural decision without a verification step.
+   - Brainstorming can stay exploratory, but the final issue body must distinguish verified facts from open questions and hypotheses.
 
 3. **Quiet Mode: defer capture.** Do not create the `--log` PR yet — the feature branch does not exist until PHASE 2. Save the brainstorm content locally and use it as the opening entry when the `--log` PR is created in PHASE 2.
 

--- a/skills/shiplog/references/phase-templates.md
+++ b/skills/shiplog/references/phase-templates.md
@@ -36,6 +36,19 @@ updated_at: <ISO_TIMESTAMP>
 - **Alternative A**: [why not chosen]
 - **Alternative B**: [why not chosen]
 
+## Sources and Verification Status
+
+Use this section when the issue includes external factual claims. If the issue is only
+about this repository's own code or docs, cite repo paths inline where useful and omit
+this section if it adds no value.
+
+- `[verified]` Claim: [external factual statement that affects the issue]
+  - **Source:** [primary source URL or official repository link]
+  - **Checked:** [what the source confirms]
+- `[unverified]` Claim or hypothesis: [idea worth preserving, but not yet confirmed]
+  - **Why unverified:** [missing source, conflicting reports, or pending experiment]
+  - **Next step:** [what must be checked before this can become a requirement]
+
 ## Tasks
 
 Each task is self-contained. A tier-3 model should be able to execute any task
@@ -43,6 +56,8 @@ using only the information in that task block, without reading the rest of this 
 When exact behavior matters, write a contract instead of relying on emphasis or tone.
 These fields also serve as the default delegation contract when a stronger model
 hands a `[tier-3]` task to a cheaper agent.
+Do not encode an `[unverified]` external claim as a fixed requirement unless the task
+includes the verification work needed to resolve it.
 
 - [ ] **Task 1: [Short title]** `[tier-3]`
   - **What:** [1-2 sentences, exactly what to do - no ambiguity]


### PR DESCRIPTION
## Summary

This PR tightens Phase 1 capture quality so external factual claims do not enter shiplog issues as unmarked assumptions. It adds an explicit verification rule in `SKILL.md` and updates the Phase 1 issue template to record verified sources versus provisional claims.

Closes #58

## Journey Timeline

### Initial Plan
Issue #58 identified a Phase 1 gap exposed while drafting #57: brainstorm output could be captured into the knowledge graph without distinguishing verified third-party facts from speculation.

### What We Discovered
- `master` already included the #51 signing changes, so the verification rule needed to fit into the signed Phase 1 workflow rather than an older template copy.
- The template needed both a dedicated verification section and a guardrail in the task contract text; adding only one of those would still let unverified claims leak into execution.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| How to handle unresolved external claims | Allow issue creation, but require explicit `[unverified]` labeling | Brainstorming stays useful without letting hypotheses masquerade as facts |
| What counts as external | Third-party tools, APIs, URLs, platform capabilities, pricing, distribution channels, and ecosystem behavior | These are the claim types most likely to drift away from the repo's local source of truth |
| How to prevent bad downstream tasking | Ban `[unverified]` claims from becoming fixed requirements unless the task includes verification work | This stops speculative facts from silently hardening into execution contracts |

### Changes Made

**Commits:**
- `c38300d` docs(#58): require source verification in phase 1

## Testing

- [x] Re-read `skills/shiplog/SKILL.md` Phase 1 guidance after the patch
- [x] Re-read `skills/shiplog/references/phase-templates.md` Phase 1 template after the patch
- [x] Confirmed both files now align on internal vs external claims, `[unverified]` marking, and the task-contract restriction

**Verification summary:** docs-only change; no automated tests run.

## Stacked PRs / Related

- Related: #57
- Related: #49

## Knowledge for Future Reference

Shiplog can preserve exploratory thinking without degrading the knowledge graph if hypotheses stay visibly provisional. The important boundary is not "only create issues when everything is known," but "never record unknown third-party facts as if they were already verified."

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
