### PR TITLE
docs(#49): define edit provenance rules

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -93,7 +93,7 @@ See `references/model-routing.md` for full configuration format, setup wizard, h
 
 All artifacts use `#ID` as the primary key for fast, token-efficient retrieval.
 
-**Semantic tag vocabulary** for user-facing headings: `plan`, `session-start`, `commit-note`, `discovery`, `blocker`, `review-handoff`, `worklog`, `history`. Format: `[shiplog/<kind>] <human title>`.
+**Semantic tag vocabulary** for user-facing headings: `plan`, `session-start`, `commit-note`, `discovery`, `blocker`, `review-handoff`, `worklog`, `history`, `amendment`. Format: `[shiplog/<kind>] <human title>`.
 
 | Artifact | Convention | Example |
 |----------|-----------|---------|
@@ -391,13 +391,13 @@ Every shiplog artifact (comments, PR bodies, review sign-offs) must carry a prov
 
 | Field | Values | Examples |
 |-------|--------|---------|
-| `role` | `Authored-by` or `Reviewed-by` | — |
+| `role` | `Authored-by`, `Updated-by`, or `Reviewed-by` | — |
 | `family` | Provider name, lowercase | `claude`, `openai`, `google` |
 | `version` | Model identifier | `opus-4.6`, `sonnet-4`, `gpt-5.4` |
 | `tool` | Runtime environment, lowercase | `claude-code`, `codex`, `cursor` |
 | `qualifier` | Optional tool-specific metadata | `effort: high`, `effort: medium` |
 
-**Searching:** `Authored-by:` → all authorship. `claude/` → all Claude artifacts. `(codex` → all Codex artifacts (matches both `(codex)` and `(codex, effort: high)`).
+**Searching:** `Authored-by:` → original authorship. `Updated-by:` → later material editors. `Reviewed-by:` → review artifacts. `claude/` → all Claude artifacts. `(codex` → all Codex artifacts (matches both `(codex)` and `(codex, effort: high)`).
 
 **Model detection per tool:**
 
@@ -409,5 +409,15 @@ Every shiplog artifact (comments, PR bodies, review sign-offs) must carry a prov
 | Other | Best available model identifier | `<family>/<version> (<tool>)` |
 
 **Correction rule:** If a shiplog artifact carries an incorrect or incomplete signature, correct it in place when the platform allows editing. Otherwise post an immediate follow-up correction.
+
+**Edit provenance rule:**
+- `Authored-by:` records the original author of an artifact body.
+- `Updated-by:` records a later model or human who materially edits that same artifact body. Preserve the original `Authored-by:` line and append a new `Updated-by:` line for each material edit, newest last.
+- `Reviewed-by:` is review-only. Do not use it for authorship or edit attribution.
+- A **material edit** changes meaning, facts, scope, requirements, acceptance criteria, verification results, review disposition, or a handoff contract. Typos, formatting cleanups, and link-only fixes are cosmetic and do not need `Updated-by:`.
+- **Edit in place** when the artifact is meant to stay the single canonical current body: issue bodies, PR bodies, and latest-wins status/history artifacts. When such an artifact is materially edited, refresh its envelope `updated_at` and add `updated_by` plus `edit_kind` fields when an envelope exists.
+- **Post an amendment artifact** instead of silently rewriting when the artifact is an accumulated event whose original text matters for auditability: handoffs, verification comments, commit-note comments, review sign-offs, and other major signed timeline entries. Use a new signed artifact that references the prior artifact and add envelope `amends` or `supersedes` markers as appropriate.
+- Use `supersedes` when the new artifact replaces the old one as the canonical current version. Use `amends` when the new artifact corrects or clarifies the earlier artifact but both should remain visible in history.
+- If the platform does not expose reliable edit history or does not allow editing, prefer an amendment artifact even for corrections that would otherwise be safe in place.
 
 Model identity detection is also used by model-tier routing to verify the current model matches the recommended tier. See [Model-Tier Routing](#model-tier-routing).

--- a/skills/shiplog/references/artifact-envelopes.md
+++ b/skills/shiplog/references/artifact-envelopes.md
@@ -44,6 +44,9 @@ Place the envelope at the **top** of the artifact body (issue body, PR body, or 
 | `phase` | no | integer | Shiplog phase number (1-7) when the artifact was created |
 | `profile` | no | string | Active verification profile name, if any |
 | `updated_at` | yes | ISO 8601 | When the envelope was last written or refreshed |
+| `updated_by` | no | string | Latest material editor of this artifact when it was edited in place |
+| `edit_kind` | no | string | Edit classification: `correction`, `amendment`, `rewrite`, or `cosmetic` |
+| `amends` | no | string | Reference to the earlier artifact this one corrects or clarifies without replacing |
 | `supersedes` | no | string | Reference to the artifact this one replaces (see §3) |
 | `superseded_by` | no | string | Back-pointer added to the older artifact when superseded |
 
@@ -52,6 +55,9 @@ Place the envelope at the **top** of the artifact body (issue body, PR body, or 
 - **Issue/PR numbers:** bare integers, no `#` prefix — e.g., `issue: 42` not `issue: #42`.
 - **Branch names:** full branch name — e.g., `branch: issue/42-auth-middleware`.
 - **Timestamps:** ISO 8601 with timezone — e.g., `2026-03-14T12:00:00Z`.
+- **`updated_by`:** normalized like the signature body without the role prefix — e.g., `openai/gpt-5.4 (codex, effort: high)`.
+- **`edit_kind`:** use `correction` for factual or signature fixes, `amendment` for clarifications that preserve the original event, `rewrite` for substantial in-place rewrites, and `cosmetic` only when recording a non-semantic cleanup intentionally.
+- **Amendment/supersession references:** use the same `<artifact-location>#<kind>` format for `amends`, `supersedes`, and `superseded_by`.
 - **Supersession references:** `<artifact-location>#<kind>` — e.g., `issue/42#state` or `pr/55#verification`. See §3 for resolution.
 - **Unknown fields:** agents MUST ignore fields they do not recognize. This preserves forward compatibility as the schema evolves.
 
@@ -79,6 +85,7 @@ updated_at: 2026-03-14T14:30:00Z
 | `verification` | Evidence of testing, review, or quality check | accumulating | issues, PRs |
 | `commit-note` | Reasoning behind a specific commit | accumulating | issues |
 | `review-handoff` | Review request or review completion artifact | accumulating | PRs |
+| `amendment` | Correction or clarification for an existing signed artifact | accumulating | issues, PRs |
 | `blocker` | Something preventing progress | latest-wins | issues |
 | `history` | Retrospective summary for knowledge retrieval | latest-wins | issues, PRs |
 
@@ -99,6 +106,8 @@ updated_at: 2026-03-14T14:30:00Z
 
 **`review-handoff`** — Write when requesting or completing a PR review. Distinct from `handoff` (tier/tool switch) — this is specifically about code review.
 
+**`amendment`** — Write when a later model materially corrects, clarifies, or annotates an existing signed artifact without silently erasing the prior text. Include `amends` for additive corrections; include `supersedes` if the amendment becomes the new canonical replacement.
+
 **`blocker`** — Write when something blocks progress. Supersedes the previous blocker if the blocking condition changes. Include `status: blocked`.
 
 **`history`** — Write when summarizing a completed journey (e.g., PR body timeline, session-end recap). Useful for future retrieval queries.
@@ -114,6 +123,7 @@ Envelope `kind` is the machine key. The `[shiplog/<tag>]` heading is the human k
 | `verification` | `commit-note`, `review-handoff` |
 | `commit-note` | `commit-note` |
 | `review-handoff` | `review-handoff` |
+| `amendment` | `amendment` |
 | `blocker` | `blocker` |
 | `history` | `history`, `worklog` |
 
@@ -139,6 +149,12 @@ When a newer artifact intentionally replaces an older one, the author SHOULD add
 - `superseded_by: issue/42#state@2026-03-14T15:00:00Z` on the old artifact (best-effort — editing old comments may not always be practical).
 
 The `@timestamp` suffix disambiguates when multiple artifacts of the same kind exist.
+
+### Amendments versus supersession
+
+- Use `amends` when the new artifact corrects or clarifies an earlier one but the original event should still be read as part of the timeline.
+- Use `supersedes` when the new artifact should be treated as the current canonical replacement for the old one.
+- For in-place edits to an existing artifact, keep the same artifact location, refresh `updated_at`, and record `updated_by` plus `edit_kind` on that artifact instead of inventing a self-reference.
 
 ### When markers are absent
 

--- a/skills/shiplog/references/closure-and-review.md
+++ b/skills/shiplog/references/closure-and-review.md
@@ -158,7 +158,7 @@ Disposition: approve
 Scope: full diff — references/artifact-envelopes.md structure, SKILL.md pointer
 ```
 
-This is the temporary format. When #33 (authored-artifact signatures) lands, it will formalize provenance more completely. Until then, this format provides enough structure for auditability.
+This remains the canonical review sign-off block. Authorship and edit provenance are tracked separately via `Authored-by:` and `Updated-by:` artifacts; the review disposition still lives here.
 
 ### What constitutes "different model"
 
@@ -172,7 +172,7 @@ This is the temporary format. When #33 (authored-artifact signatures) lands, it 
 When asked to review PRs, whether one PR or many (e.g., "review PRs", "check for PRs to review", "review PR #56"), the reviewing agent should:
 
 1. List open PRs on the repository.
-2. For each PR, inspect the newest signed shiplog author-side artifact you can verify for that work (for example the PR body `Authored-by:` line, or a newer linked commit-note / handoff artifact) and any existing `Reviewed-by:` sign-offs.
+2. For each PR, inspect the newest signed shiplog author-side artifact you can verify for that work (for example the PR body `Authored-by:` or `Updated-by:` line, or a newer linked commit-note / handoff / amendment artifact) and any existing `Reviewed-by:` sign-offs.
 3. **Skip PRs where the newest verifiable author-side artifact or most recent review sign-off was authored by the same model and version.** Reviewing your own work adds no independent assurance — it is the anti-pattern this protocol exists to prevent.
 4. **Review PRs where the latest activity is from a different model.** These are candidates for cross-model review.
 5. If all open PRs were last touched by the current model, inform the user:
@@ -181,7 +181,7 @@ When asked to review PRs, whether one PR or many (e.g., "review PRs", "check for
 
 **Where to find review artifacts:** Shiplog review sign-offs are posted as issue/PR comments, not formal GitHub review events (see §4 GitHub API constraint). When checking for existing reviews, search the PR body plus issue/PR comments for `Reviewed-by:` and `Disposition:` lines. Do not rely on the formal reviews API endpoint alone — it will miss most AI-operated reviews.
 
-**What counts as "last touched":** The most recent signed shiplog artifact you can verify on either side: (a) the newest author-side `Authored-by:` artifact associated with the work, or (b) the most recent review `Reviewed-by:` sign-off. Do not treat raw Git commit metadata as model provenance; shiplog authorship lives in signed artifacts, not the commit object. If the branch moved after the last visible signed author artifact and the responsible model is unclear, treat authorship as unknown and do not claim a gate-satisfying same-model review.
+**What counts as "last touched":** The most recent signed shiplog artifact you can verify on either side: (a) the newest author-side `Authored-by:` or `Updated-by:` artifact associated with the work, or a newer amendment artifact, or (b) the most recent review `Reviewed-by:` sign-off. Do not treat raw Git commit metadata as model provenance; shiplog provenance lives in signed artifacts, not the commit object. If the branch moved after the last visible signed author artifact and the responsible model is unclear, treat authorship as unknown and do not claim a gate-satisfying same-model review.
 
 ---
 

--- a/skills/shiplog/references/phase-templates.md
+++ b/skills/shiplog/references/phase-templates.md
@@ -639,3 +639,63 @@ Scope: <what was reviewed>
 ```
 
 See `references/closure-and-review.md` §3-5 for the full multi-model review protocol.
+
+---
+
+## Edit Provenance
+
+When a later model materially edits an existing signed artifact, choose one of these patterns.
+
+### In-place edit footer
+
+Use this when the artifact should remain the single canonical current body
+(issue body, PR body, or a latest-wins state/history artifact). Preserve the
+original `Authored-by:` line and append:
+
+```markdown
+Updated-by: <family>/<version> (<tool>)
+Edit-kind: correction | amendment | rewrite
+Edit-note: [1 sentence describing what changed and why]
+```
+
+If the artifact carries an envelope, refresh the metadata too:
+
+```html
+<!-- shiplog:
+updated_at: <ISO_TIMESTAMP>
+updated_by: <family>/<version> (<tool>)
+edit_kind: correction | amendment | rewrite
+-->
+```
+
+### Amendment artifact
+
+Use this when silently rewriting the existing artifact would hide an important
+event in the timeline: handoffs, verification comments, commit notes, review
+sign-offs, or other major signed comments.
+
+```markdown
+<!-- shiplog:
+kind: amendment
+issue: <ISSUE_NUMBER>
+pr: <PR_NUMBER>
+updated_at: <ISO_TIMESTAMP>
+amends: <artifact-reference>
+-->
+
+## [shiplog/amendment] #<ISSUE_NUMBER>: <brief description>
+
+**Target:** [URL to the artifact being corrected or clarified]
+**Edit kind:** correction | amendment | rewrite
+**Why new artifact:** [why this should not be a silent in-place edit]
+**What changed:**
+- [change 1]
+- [change 2]
+
+**Current canonical artifact:** [URL to the body/comment that should now be treated as current, or `this comment`]
+
+Authored-by: <family>/<version> (<tool>)
+```
+
+If the amendment fully replaces the old artifact as current, swap `amends:` for
+`supersedes:` and update the old artifact with `superseded_by:` when practical.


### PR DESCRIPTION
## Summary

This PR adds the missing edit-provenance layer to shiplog's artifact model. It defines how later material edits are attributed, distinguishes in-place canonical updates from amendment artifacts, and teaches envelope/review retrieval logic how to preserve that provenance instead of collapsing it into the original authorship line.

Closes #49

## Journey Timeline

### Initial Plan
Issue #49 identified the gap left after authorship signatures and review sign-offs landed: a later model could materially rewrite an issue body, PR body, or signed comment without a standard way to record who changed it or whether the prior text was amended versus superseded.

### What We Discovered
- The existing provenance model already had the right building blocks, but they were split: signatures handled authorship, envelopes handled supersession, and review selection only looked at original author-side artifacts.
- The cleanest rule is dual-path: keep canonical bodies editable in place with `Updated-by`, but require separate amendment artifacts for accumulated events whose original text matters to the timeline.
- `closure-and-review.md` still carried stale wording that treated authored signatures as future work, so fixing #49 cleanly required aligning the review doc with the current provenance model.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| How to distinguish original authorship from later edits | Add `Updated-by:` alongside `Authored-by:` and `Reviewed-by:` | Multi-model artifact histories need to show both who created the artifact and who later changed it |
| When to edit in place | Only for single-canonical-current artifacts such as issue bodies, PR bodies, and latest-wins state/history artifacts | These are maintained as the current source of truth, so in-place updates are appropriate if the editor is recorded |
| When to require a new artifact | Use amendment artifacts for handoffs, verification comments, commit notes, review sign-offs, and other major signed timeline events | Rewriting those silently would erase timeline evidence that later readers may need |
| How machine-readable retrieval should track edits | Add `updated_by`, `edit_kind`, and `amends` envelope fields and teach review selection to consider later author-side edits | Retrieval should not treat original authorship as the last touch when a different model materially edited the artifact later |

### Changes Made

**Commits:**
- `9c2a6ba` docs(#49): define edit provenance rules

## Testing

- [x] Re-read the `### Agent identity signing` section in `skills/shiplog/SKILL.md`
- [x] Re-read the envelope field schema and amendment guidance in `skills/shiplog/references/artifact-envelopes.md`
- [x] Re-read the new edit-provenance templates in `skills/shiplog/references/phase-templates.md`
- [x] Re-read the review-target selection logic in `skills/shiplog/references/closure-and-review.md`
- [x] Confirmed those files now agree on `Updated-by`, amendment artifacts, and last-touch review semantics

**Verification summary:** docs-only change; no automated tests run.

## Stacked PRs / Related

- Related: #42
- Related: #32
- Related: #33
- Related: #24
- Related: #26

## Knowledge for Future Reference

Provenance has three different jobs now: `Authored-by` says who created the artifact, `Updated-by` says who later changed that same canonical body, and `Reviewed-by` says who independently evaluated the work. When the old text is itself part of the evidence trail, the correction should be a new amendment artifact instead of a silent rewrite.

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
