### PR TITLE
feat(#17): add closure verifier workflow

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -248,6 +248,8 @@ Discovery made during work
 
 5. **Link and store.** PR body includes `Closes #<issue>`. Store key learning in knowledge graph.
 
+6. **Closure verification (optional).** When an issue will be closed manually or the mapping between the evidence and the issue is non-obvious, optionally delegate a bounded verifier agent per `references/closure-and-review.md`. The verifier audits the evidence and returns a verification note, but the higher-tier actor still decides whether to close, keep open, or escalate.
+
 ---
 
 ## PHASE 6: Knowledge Retrieval

--- a/skills/shiplog/references/closure-and-review.md
+++ b/skills/shiplog/references/closure-and-review.md
@@ -56,6 +56,42 @@ If the match between the issue and the evidence is ambiguous:
 3. Tag the issue for human review or escalate to a higher-tier model.
 4. If a verifier agent is available, delegate the ambiguity check per `references/model-routing.md` delegation protocol.
 
+### Optional verifier-agent workflow
+
+Use this workflow when closure evidence is specific enough to audit but repetitive enough to delegate.
+The supervising model remains responsible for the closure decision.
+
+**Supervisor responsibilities:**
+- choose the candidate evidence links to inspect
+- assemble a bounded verifier contract using the delegation protocol from `references/model-routing.md`
+- keep closure judgment for ambiguous issues, umbrella issues, and any case where the verifier reports mismatch or low confidence
+
+**Verifier may:**
+- read the issue body and linked discussion
+- inspect candidate commits and merged PRs
+- inspect current file state on the default branch
+- produce a signed verification note with evidence, confidence, and a recommended action
+
+**Verifier may not:**
+- reinterpret vague issue intent
+- decide that a partial fix is "good enough"
+- close umbrella issues or mixed-status roadmap issues on its own
+- close any issue directly
+- resolve ambiguous evidence by inference
+
+**Required verifier output:**
+- candidate fix artifact links
+- whether the fix is merged to the default branch
+- which parts of the issue are satisfied by the diff or current file state
+- any unresolved mismatch or ambiguity
+- confidence: `high` | `medium` | `low`
+- recommended action: `close` | `keep open` | `escalate`
+
+**Decision rule:**
+- Only close when the supervising model agrees with the verifier's evidence review and the verifier returns `close` with high confidence and no unresolved mismatch.
+- If the verifier returns `keep open` or `escalate`, do not close the issue.
+- When a verifier note materially informed the closure decision, post it as an issue comment before closing so the audit trail stays durable.
+
 ### Umbrella issues
 
 Umbrella issues (tracking multiple sub-issues or a roadmap) require:

--- a/skills/shiplog/references/phase-templates.md
+++ b/skills/shiplog/references/phase-templates.md
@@ -550,6 +550,62 @@ See `references/closure-and-review.md` for the full closure and review protocol.
 
 ---
 
+## Closure Verifier Handoff
+
+Use this when a stronger model wants a bounded verifier agent to audit closure
+evidence before an issue is manually closed.
+
+```markdown
+## [#<ID>] closure verifier handoff: <issue title>
+
+**Delegated by:** <family>/<version> (<tool>)
+**Target tier:** tier-3
+**Why delegation fits:** [why this closure audit is bounded and evidence-driven]
+
+### Goal
+Verify whether the listed evidence justifies closing issue #<ID>. Do not close the issue yourself.
+
+### Allowed sources
+- issue body and linked discussion
+- listed commits and merged PRs
+- current file state on the default branch
+
+### Contract
+- **Candidate evidence:** [commit URLs, PR URLs, or artifact links to inspect]
+- **Must not decide:** vague intent, partial-fix sufficiency, umbrella mixed status, or the closure action itself
+- **Stop and ask if:** [conditions that require escalation to the supervising model]
+- **Verification required:** confirm merge status, compare the diff or file state to the issue claim, and record any unresolved mismatch
+- **Return artifact:** closure verification note
+- **Decision budget:** `none`
+
+Authored-by: <family>/<version> (<tool>)
+```
+
+## Closure Verification Note
+
+Post the verifier output as a signed issue comment when it materially informs a
+closure decision.
+
+```markdown
+<!-- shiplog:
+kind: verification
+issue: <ID>
+updated_at: <ISO_TIMESTAMP>
+-->
+
+## [shiplog/verification] #<ID>: Closure audit
+
+**Candidate evidence:** [links inspected]
+**Merged to default branch:** yes | no | unclear
+**Satisfied scope:** [which issue claims are satisfied]
+**Unresolved mismatch:** [gap, ambiguity, or `None`]
+**Confidence:** high | medium | low
+**Recommended action:** close | keep open | escalate
+
+Authored-by: <family>/<version> (<tool>)
+```
+
+---
 ## Review Sign-Off Comment
 
 When reviewing a PR, include this sign-off block:


### PR DESCRIPTION
## Summary

This PR adds an optional verifier-agent workflow for evidence-based issue closure. It gives shiplog a bounded way to delegate repetitive closure audits to a cheaper verifier while keeping the actual closure judgment with the supervising model.

Closes #17

## Journey Timeline

### Initial Plan
Issue #17 scoped a narrow closure-verification workflow: reuse the existing delegation contract, let a verifier audit candidate evidence, and require a structured note with a close/keep-open/escalate recommendation.

### What We Discovered
- The closure policy already required evidence and a verification note, but the repository still lacked the actual verifier workflow that would produce that note.
- The general delegation machinery is already present in `references/model-routing.md`, so the clean implementation was to bind closure verification to that existing contract rather than introduce a new orchestration model.
- Umbrella issue #18 should remain open until this PR merges, because the closure protocol requires merged evidence before the umbrella summary comment can honestly claim Stage 3 is complete.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Who owns closure judgment | The supervising model, not the verifier | Evidence auditing is delegable; ambiguity resolution and closure authority are not |
| What the verifier may inspect | Issue body/discussion, candidate commits/merged PRs, and current default-branch file state | That is the minimal evidence surface needed to decide whether the issue is actually resolved |
| What the verifier must return | Evidence links, merged status, satisfied scope, unresolved mismatch, confidence, and close/keep-open/escalate recommendation | The supervising model needs a durable, auditable note rather than an informal thumbs-up |
| When verifier output becomes durable history | Post the verification note as an issue comment whenever it materially informed closure | The workflow is only trustworthy if later readers can see both the evidence and the audit path |

### Changes Made

**Commits:**
- `6ae64e7` feat(#17): add closure verifier workflow

## Testing

- [x] Re-read the new closure-verification step in `skills/shiplog/SKILL.md`
- [x] Re-read the optional verifier workflow in `skills/shiplog/references/closure-and-review.md`
- [x] Re-read the new verifier handoff and verifier note templates in `skills/shiplog/references/phase-templates.md`
- [x] Confirmed those files agree that the verifier audits evidence but never closes the issue directly

**Verification summary:** docs-only change; no automated tests run.

## Stacked PRs / Related

- Related: #15
- Related: #16
- Related: #18

## Knowledge for Future Reference

Closure verification is now the same kind of bounded delegation as execution handoffs: the stronger model defines the audit contract, the cheaper verifier does the repetitive inspection, and the repository preserves the verification note as durable evidence. The key boundary is that closure authority stays upward even when the audit work is delegated downward.

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
