### PR TITLE
docs(#71): require default GitHub publication for PR review artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,7 @@
 @./skills/shiplog/SKILL.md
+
+## Repo-Local Rules
+
+### PR review publication
+
+When reviewing a PR in this repository, the signed shiplog review artifact must be posted on the PR as a GitHub comment by default. Do not consider a PR review complete until the artifact is published. If GitHub posting is blocked, provide the exact signed artifact text for manual posting and note that publication is pending.

--- a/skills/shiplog/references/closure-and-review.md
+++ b/skills/shiplog/references/closure-and-review.md
@@ -256,6 +256,27 @@ Note: Self-review recorded as audit trail. This PR must not merge until an indep
 
 **Self-review is an audit artifact, not a gate-satisfying event.** It exists so the review intent is visible in the timeline, but it confers no merge authorization. There are no exceptions to the independent review requirement.
 
+### Review completion: default publication
+
+A PR review is not complete until the signed review artifact is posted on the PR as a GitHub comment. Local analysis that exists only in the agent's chat session does not satisfy the review protocol — the canonical artifact must be durable and visible on the PR timeline.
+
+**Default behavior:** After completing the review analysis and summarizing findings to the user, post the signed review artifact on the PR. Then link the posted comment in the user-facing response.
+
+**Explicit exceptions (require user opt-in):**
+- The user explicitly requested a dry run or local-only review.
+- The user explicitly asked not to post to GitHub.
+
+Unless one of these exceptions applies, publication is the assumed completion step. The agent should not wait for a follow-up prompt to post.
+
+**When GitHub posting is blocked:** If the agent cannot reach GitHub (network failure, API error, permission issue):
+
+1. Report the blocker to the user immediately.
+2. Provide the exact signed review artifact text in the chat response so the user can post it manually or the agent can retry later.
+3. Do not mark the review as complete — note that publication is pending.
+4. On next opportunity, retry posting the artifact or confirm the user has posted it.
+
+The signed artifact text is the deliverable. GitHub publication is the delivery mechanism. When the mechanism fails, preserve the deliverable intact and make the failure visible.
+
 ---
 
 ## 5. Merge Authorization


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 71
pr: 72
branch: issue/71-default-review-publication
status: resolved
updated_at: 2026-03-15T00:00:00Z
-->

## Summary

Establishes that PR review artifacts must be posted on the PR as a GitHub comment by default — not left only in the agent's chat session. Adds explicit exceptions for dry runs and fallback behavior when GitHub posting is blocked.

Closes #71

## Journey Timeline

### Initial Plan
Issue #71 identified a workflow gap exposed during the PR #70 review: the signed review artifact was completed locally but only posted to GitHub after an explicit follow-up. The fix is to make publication the default completion step.

### What We Discovered
- The change fits cleanly as a subsection within §4 (Review Execution Ladder) of closure-and-review.md, avoiding section renumbering.
- No existing cross-references needed updating.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Placement in closure-and-review.md | New subsection at end of §4 | Avoids renumbering §5 (Merge Authorization) and preserves existing cross-references |
| CLAUDE.md guardrail | Concise mirror of the protocol rule | Repo-level reinforcement prevents drift from the shiplog protocol |

### Changes Made

**Commits:**
- `6fee069` docs(#71): require default GitHub publication for PR review artifacts

**Files:**
- `skills/shiplog/references/closure-and-review.md` — added "Review completion: default publication" subsection covering default behavior, explicit exceptions, and blocked-access fallback
- `CLAUDE.md` — added "Repo-Local Rules" section with PR review publication guardrail

## Testing

- [x] Verified the updated closure-and-review.md explicitly covers default publication, dry-run exception, and blocked-access fallback
- [x] Verified CLAUDE.md still imports shiplog and now states the publication rule
- [x] No existing section numbers or cross-references broken

## Knowledge for Future Reference

The open questions from the issue remain open:
- Whether this default publication rule should also live in higher-level agent instructions used across repos
- Whether shiplog should later distinguish `comment` as an explicit `Disposition:` value for non-blocking signed reviews

---
Authored-by: claude/opus-4.6 (claude-code)
*Captain's log — PR timeline by [shiplog](https://github.com/devallibus/shiplog)*