### PR TITLE
fix(#77): link self-review to contract generation

### DIFF
--- a/skills/shiplog/references/closure-and-review.md
+++ b/skills/shiplog/references/closure-and-review.md
@@ -256,6 +256,8 @@ Note: Self-review recorded as audit trail. This PR must not merge until an indep
 
 **Self-review is an audit artifact, not a gate-satisfying event.** It exists so the review intent is visible in the timeline, but it confers no merge authorization. There are no exceptions to the independent review requirement.
 
+**Contract requirement:** A self-review artifact MUST include or be immediately followed by a review contract (see "Fallback: Generate a review contract" above). The self-review records intent; the contract enables resolution. Posting a self-review without a contract leaves the PR in a dead-end state where the gate is unsatisfied and no reviewer has the information needed to act.
+
 ### Review completion: default publication
 
 A PR review is not complete until the signed review artifact is posted on the PR as a GitHub comment. Local analysis that exists only in the agent's chat session does not satisfy the review protocol — the canonical artifact must be durable and visible on the PR timeline.


### PR DESCRIPTION
## Summary

- Adds a **Contract requirement** paragraph to the self-review subsection in `closure-and-review.md` §4
- Links the "audit trail only" path to the "Fallback: Generate a review contract" subsection so agents cannot post a self-review and stop without providing the contract that enables resolution

Closes #77

## Journey Timeline

**Root cause:** §4's three review execution subsections (spawn agent → generate contract → self-review) were independent. An agent following subsection 3 alone correctly posted the self-review but had no instruction to also generate the contract. Observed on PR #70.

**Fix:** One paragraph addition — the self-review section now explicitly requires attaching a review contract when the gate is unsatisfied. Verified that Phase 5 integration (line 322) already says "If not, generate the review contract" — no SKILL.md change needed.

## Key Decisions

- Added the rule to the self-review subsection rather than restructuring the ladder, keeping the change minimal and targeted.

## Changes

| File | Change |
|------|--------|
| `skills/shiplog/references/closure-and-review.md` | Added contract requirement paragraph after self-review closing statement |

## Testing

- Verified the new paragraph references the correct subsection heading
- Confirmed Phase 5 integration section already covers contract generation at the PR level
- No other files need changes

Authored-by: claude/opus-4.6 (claude-code)