### PR TITLE
chore(#83): install shiplog as a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "shiplog",
+  "owner": {
+    "name": "devallibus"
+  },
+  "metadata": {
+    "description": "Git-as-knowledge-graph workflow for traceability across issues, branches, commits, reviews, and PRs."
+  },
+  "plugins": [
+    {
+      "name": "shiplog",
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
   },
   "homepage": "https://github.com/devallibus/shiplog",
   "repository": "https://github.com/devallibus/shiplog",
-  "license": "MIT"
+  "license": "MIT",
+  "skills": "./skills/"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-@./skills/shiplog/SKILL.md
-
-## Repo-Local Rules
-
-### PR review publication
-
-When reviewing a PR in this repository, the signed shiplog review artifact must be posted on the PR as a GitHub comment by default. Do not consider a PR review complete until the artifact is published. If GitHub posting is blocked, provide the exact signed artifact text for manual posting and note that publication is pending.


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` so the repo works as a self-hosted Claude Code marketplace
- Adds `"skills": "./skills/"` to `plugin.json` so the skill is discoverable as `shiplog:shiplog`
- Deletes `CLAUDE.md` — the `@./skills/shiplog/SKILL.md` include is replaced by plugin installation; the repo-local PR review rule is already covered by the skill's `references/closure-and-review.md`

Closes #83

## Journey Timeline

1. Investigated Claude Code plugin/marketplace system — `claude plugin marketplace add`, `claude plugin install`, manifest schemas
2. Found existing `.claude-plugin/plugin.json` was missing the `skills` field
3. No `marketplace.json` existed — required for `claude plugin marketplace add devallibus/shiplog`
4. Added marketplace manifest, updated plugin.json, deleted CLAUDE.md
5. Validated with `claude plugin validate` — passes

## Post-Merge Steps

After merging, run these commands to complete the installation:

```bash
claude plugin marketplace add devallibus/shiplog
claude plugin install shiplog@shiplog
```

The skill will then be available as `shiplog:shiplog` across all projects.

## Changes

| File | Change |
|------|--------|
| `.claude-plugin/marketplace.json` | **New** — marketplace manifest |
| `.claude-plugin/plugin.json` | Added `"skills": "./skills/"` |
| `CLAUDE.md` | **Deleted** — replaced by plugin installation |

## Testing

- `claude plugin validate` passes on the worktree
- Marketplace manifest structure matches working examples (figma-friend, orchestkit, rust-skills)

Authored-by: claude/opus-4.6 (claude-code)