### PR TITLE
feat(#85): add shiplog-managed labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ shiplog fixes this by making your git history the single source of truth — not
 | [Verification Profiles](#verification-profiles) | Configurable testing policies: behavior-spec, red-green, structural, mutation |
 | [Artifact Envelopes](#artifact-envelopes) | Machine-readable metadata for low-token agent retrieval |
 | [Agent Identity Signing](#agent-identity-signing) | Provenance tracking on every artifact — who wrote it, which model, which tool |
+| [GitHub Labels](#github-labels) | Shiplog bootstraps and applies a compact label vocabulary to issues and PRs |
 | [Discovery Protocol](#discovery-protocol) | Mid-work findings get tracked as stacked PRs or new issues, never lost |
 | [ID-First Convention](#id-first-convention) | Every artifact keyed by `#ID` — one search finds everything |
 | [Shell Portability](#shell-portability) | Full Bash and PowerShell support, cross-platform from day one |
@@ -239,6 +240,24 @@ gh pr list --search "#42" --state all       # PRs
 git log --all --oneline --grep="#42"         # commits
 ```
 
+## GitHub Labels
+
+shiplog also manages a compact repository label vocabulary so work stays filterable at a glance, even before anyone opens the issue or PR body.
+
+The skill bootstraps labels on first write, applies them at creation time, and backfills them when the mapping is obvious from shiplog conventions like `[shiplog/plan]`, `[shiplog/discovery]`, `Closes #<N>`, or Quiet Mode `--log` branches.
+
+The built-in label set is:
+- `shiplog/plan`
+- `shiplog/discovery`
+- `shiplog/blocker`
+- `shiplog/worklog`
+- `shiplog/history`
+- `shiplog/verification`
+- `shiplog/stacked`
+- `shiplog/issue-driven`
+- `shiplog/quiet-mode`
+
+`shiplog/blocker` is stateful: add it when progress is blocked, remove it when the blocker clears.
 ## Shell Portability
 
 shiplog is cross-platform from day one. All templates and commands work on both Bash (macOS/Linux) and PowerShell (Windows). The key pattern: use `gh ... --body-file <temp-file>` for multiline content instead of inline heredocs.

--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -176,6 +176,19 @@ Key rules:
 
 ---
 
+## GitHub Labels
+
+Shiplog manages a compact repo-level label vocabulary so issues and PRs stay filterable even when a reader never opens the body. See `references/labels.md` for the canonical label set, descriptions, and CLI snippets.
+
+Label rules:
+- On the first write operation in a repo, bootstrap or refresh the Shiplog labels with `gh label create --force ...`.
+- Apply Shiplog labels at creation time with `gh issue create --label` or `gh pr create --label`.
+- When resuming work on an existing issue or PR, backfill missing Shiplog labels when the mapping is high-confidence from the title, body, or branch. Do not remove user labels that are outside the `shiplog/` namespace.
+- `shiplog/blocker` is stateful. Add it when the tracked work becomes blocked and remove it when the blocker is cleared.
+- Keep the set compact. Prefer one artifact label plus at most one or two structural/state labels such as `shiplog/stacked`, `shiplog/quiet-mode`, `shiplog/issue-driven`, or `shiplog/blocker`.
+
+---
+
 ## PHASE 1: Brainstorm-to-Issue
 
 <!-- routing: tier-1 -->
@@ -184,7 +197,7 @@ Key rules:
 
 1. **Run the brainstorm.** Delegate to `superpowers:brainstorming` or `ork:brainstorming`, or brainstorm inline for quick discussions.
 
-2. **Capture as GitHub Issue (Full Mode).** Use the issue template from `references/phase-templates.md`. The issue body should include: Context, Design Summary, Approach, Alternatives Considered, Tasks (with tier tags and contract fields), and Open Questions. Sign the issue body per [Agent identity signing](#agent-identity-signing).
+2. **Capture as GitHub Issue (Full Mode).** Before the first labeled create in a repo, bootstrap the Shiplog labels per `references/labels.md`. Use the issue template from `references/phase-templates.md` and create the issue with `shiplog/plan` already applied. The issue body should include: Context, Design Summary, Approach, Alternatives Considered, Tasks (with tier tags and contract fields), and Open Questions. Sign the issue body per [Agent identity signing](#agent-identity-signing).
    Before writing the final issue body, classify factual claims:
    - **Internal claims** about this repository's code, tests, configuration, or committed docs can be verified from the repo itself. The codebase is the source of truth.
    - **External claims** about third-party tools, URLs, APIs, platform capabilities, pricing, distribution channels, or ecosystem behavior must be verified against primary sources before they are stated as facts.
@@ -205,7 +218,7 @@ Key rules:
 
 0. **Routing check (Step 0).** Run the [phase entry check](#phase-entry-check-step-0).
 
-1. **Load context.** `gh issue view <N> --json title,body,labels,comments,milestone` and search knowledge graph.
+1. **Load context.** `gh issue view <N> --json title,body,labels,comments,milestone` and search knowledge graph. If the issue is already a Shiplog artifact but is missing the obvious Shiplog labels, backfill them per `references/labels.md`.
 
 2. **Create branch (worktree-first).** The skill cannot detect concurrent agents, so shared-checkout branch switching is unsafe by default. One branch, one worktree, one agent.
 
@@ -227,7 +240,7 @@ Key rules:
    See `references/shell-portability.md` for shell-specific notes.
    **Fallback (in-place checkout):** Only when the user explicitly requests no worktree.
 
-3. **Post timeline entry.** Full Mode: comment on the issue. Quiet Mode: create `--log` branch + PR targeting the feature branch. See `references/phase-templates.md` for templates. Sign the posted artifact per [Agent identity signing](#agent-identity-signing).
+3. **Post timeline entry.** Full Mode: comment on the issue. Quiet Mode: create `--log` branch + PR targeting the feature branch and label it `shiplog/worklog`, `shiplog/quiet-mode`, and `shiplog/issue-driven`. See `references/phase-templates.md` for templates. Sign the posted artifact per [Agent identity signing](#agent-identity-signing).
 
 4. **Load plan** if it exists. Delegate to `superpowers:executing-plans` or `ork:implement`.
    For delegated or tier-3 work, the plan should define a contract: allowed files, forbidden changes, stop conditions, verification, return artifact, and decision budget.
@@ -250,9 +263,9 @@ Discovery made during work
   +-- Refactoring opportunity?             -> Create issue tagged "refactor"
 ```
 
-**Phase 3a (stack a prerequisite):** Commit current progress. Create a new issue first (so the ID exists), then create the stacked branch. Cross-reference on the parent issue. See `references/phase-templates.md` for the discovery issue template. Sign both the discovery issue and the parent cross-reference comment per [Agent identity signing](#agent-identity-signing).
+**Phase 3a (stack a prerequisite):** Commit current progress. Create a new issue first (so the ID exists), then create the stacked branch. Label the new issue `shiplog/discovery` and `shiplog/stacked`. Cross-reference on the parent issue and add `shiplog/blocker` to the parent while it is blocked. See `references/phase-templates.md` for the discovery issue template. Sign both the discovery issue and the parent cross-reference comment per [Agent identity signing](#agent-identity-signing).
 
-**Phase 3b (independent discovery):** Create new issue (same template without "blocks parent"). Add timeline comment. Continue current work. Sign each posted artifact per [Agent identity signing](#agent-identity-signing).
+**Phase 3b (independent discovery):** Create new issue (same template without "blocks parent") and label it `shiplog/discovery`. Add timeline comment. Continue current work. Sign each posted artifact per [Agent identity signing](#agent-identity-signing).
 
 ---
 
@@ -280,9 +293,9 @@ Discovery made during work
 
 1. **Pre-PR checks.** Delegate to `ork:create-pr` or `superpowers:finishing-a-development-branch`.
 
-2. **Create PR (Full Mode).** Use the PR timeline template from `references/phase-templates.md`. Body includes: Summary, `Closes #<N>`, Journey Timeline, Key Decisions, Changes, Testing, and Knowledge for Future Reference. Sign the PR body per [Agent identity signing](#agent-identity-signing).
+2. **Create PR (Full Mode).** Use the PR timeline template from `references/phase-templates.md`. Create the PR with `shiplog/history` and `shiplog/issue-driven` already applied. Body includes: Summary, `Closes #<N>`, Journey Timeline, Key Decisions, Changes, Testing, and Knowledge for Future Reference. Sign the PR body per [Agent identity signing](#agent-identity-signing).
 
-3. **Quiet Mode.** Create a clean feature PR (no shiplog content). Add a final summary comment to the `--log` PR. Sign the summary comment per [Agent identity signing](#agent-identity-signing).
+3. **Quiet Mode.** Create a clean feature PR (no shiplog content). Add a final summary comment to the `--log` PR and keep its `shiplog/worklog`, `shiplog/quiet-mode`, and `shiplog/issue-driven` labels current. Remove `shiplog/blocker` when the blocker is actually cleared. Sign the summary comment per [Agent identity signing](#agent-identity-signing).
 
 4. **Review gate.** Every PR requires cross-model review before merge. See `references/closure-and-review.md` for the review protocol, sign-off format, and merge authorization rules. Sign every review artifact per [Agent identity signing](#agent-identity-signing).
 
@@ -313,6 +326,8 @@ Discovery made during work
 1. **Add timeline comments** when: starting a new session, changing approach, finding something unexpected, completing a milestone, or getting blocked. Sign each timeline comment per [Agent identity signing](#agent-identity-signing).
 
 2. **Use the standard format.** See `references/phase-templates.md` for the comment format. Comment types: `session-start`, `session-resume`, `milestone`, `discovery`, `approach-change`, `blocker`, `session-end`.
+
+3. **Keep state labels honest.** Add `shiplog/blocker` to the tracked issue or `--log` PR when a blocker comment means work cannot proceed. Remove it as soon as a later timeline update or stacked prerequisite resolution clears the block.
 
 Delegate automatic checkbox updates to `ork:issue-progress-tracking` if available.
 

--- a/skills/shiplog/references/labels.md
+++ b/skills/shiplog/references/labels.md
@@ -1,0 +1,71 @@
+# GitHub Labels
+
+Use this file when Shiplog needs to bootstrap, apply, or repair repository labels.
+
+## Canonical label set
+
+| Label | Use when | Color | Description |
+|------|----------|-------|-------------|
+| `shiplog/plan` | The issue is the planning artifact created from a brainstorm | `0B7285` | Brainstorm captured as a planning issue |
+| `shiplog/discovery` | The issue was created from an in-flight discovery | `1D6F42` | Work discovered during another issue or PR |
+| `shiplog/blocker` | The tracked work is currently blocked | `C92A2A` | Progress is blocked and needs unblocking |
+| `shiplog/worklog` | The PR is a Quiet Mode `--log` knowledge PR | `7C6F64` | Knowledge-log PR for Quiet Mode work |
+| `shiplog/history` | The PR is the final timeline/history artifact for the work | `495057` | Final history-bearing Shiplog PR |
+| `shiplog/verification` | The issue or PR mainly audits evidence, review readiness, or closure status | `5F3DC4` | Verification, closure audit, or review evidence |
+| `shiplog/stacked` | The issue or PR is a stacked prerequisite or child of another work item | `E67700` | Stacked dependency or prerequisite |
+| `shiplog/issue-driven` | The PR is explicitly tied to a tracking issue | `1971C2` | PR is linked to a Shiplog issue |
+| `shiplog/quiet-mode` | The PR is part of Quiet Mode logging rather than the clean feature PR | `6741D9` | Quiet Mode log artifact |
+
+## Bootstrap
+
+Run this once before the first labeled `gh issue create` or `gh pr create` in a repository, then rerun it whenever the label descriptions need to be refreshed.
+
+```bash
+gh label create "shiplog/plan" --color 0B7285 --description "Brainstorm captured as a planning issue" --force
+gh label create "shiplog/discovery" --color 1D6F42 --description "Work discovered during another issue or PR" --force
+gh label create "shiplog/blocker" --color C92A2A --description "Progress is blocked and needs unblocking" --force
+gh label create "shiplog/worklog" --color 7C6F64 --description "Knowledge-log PR for Quiet Mode work" --force
+gh label create "shiplog/history" --color 495057 --description "Final history-bearing Shiplog PR" --force
+gh label create "shiplog/verification" --color 5F3DC4 --description "Verification, closure audit, or review evidence" --force
+gh label create "shiplog/stacked" --color E67700 --description "Stacked dependency or prerequisite" --force
+gh label create "shiplog/issue-driven" --color 1971C2 --description "PR is linked to a Shiplog issue" --force
+gh label create "shiplog/quiet-mode" --color 6741D9 --description "Quiet Mode log artifact" --force
+```
+
+## Auto-label mapping
+
+Use high-confidence mapping only.
+
+| Signal | Labels |
+|--------|--------|
+| Issue title starts with `[shiplog/plan]` | `shiplog/plan` |
+| Issue title starts with `[shiplog/discovery]` | `shiplog/discovery` |
+| Discovery issue explicitly blocks a parent or is created as a prerequisite | `shiplog/discovery`, `shiplog/stacked` |
+| PR title starts with `[shiplog/worklog]` or the branch ends with `--log` | `shiplog/worklog`, `shiplog/quiet-mode` |
+| Full-mode PR body follows the timeline template and includes `Closes #<N>` | `shiplog/history`, `shiplog/issue-driven` |
+| PR branch matches `issue/<N>-...` or the PR body includes `Closes #<N>` | `shiplog/issue-driven` |
+| Issue or PR exists mainly to audit closure, review, or verification evidence | `shiplog/verification` |
+| Timeline state says blocked and work cannot proceed | add `shiplog/blocker` |
+| Timeline state says unblocked, resumed, or prerequisite resolved | remove `shiplog/blocker` |
+
+## Backfill and repair
+
+Inspect labels before changing them:
+
+```bash
+gh issue view <ISSUE_NUMBER> --json labels
+gh pr view <PR_NUMBER> --json labels
+```
+
+Add or repair labels without touching user labels outside the `shiplog/` namespace:
+
+```bash
+gh issue edit <ISSUE_NUMBER> --add-label "shiplog/plan"
+gh issue edit <ISSUE_NUMBER> --add-label "shiplog/discovery" --add-label "shiplog/stacked"
+gh issue edit <ISSUE_NUMBER> --add-label "shiplog/blocker"
+gh issue edit <ISSUE_NUMBER> --remove-label "shiplog/blocker"
+gh pr edit <PR_NUMBER> --add-label "shiplog/worklog" --add-label "shiplog/quiet-mode"
+gh pr edit <PR_NUMBER> --add-label "shiplog/history" --add-label "shiplog/issue-driven"
+gh pr edit <PR_NUMBER> --add-label "shiplog/verification"
+gh pr edit <PR_NUMBER> --remove-label "shiplog/blocker"
+```

--- a/skills/shiplog/references/phase-templates.md
+++ b/skills/shiplog/references/phase-templates.md
@@ -10,6 +10,7 @@ For shell portability guidance, see `references/shell-portability.md`.
 
 ```bash
 gh issue create \
+  --label "shiplog/plan" \
   --title "[shiplog/plan] Brief title describing the work" \
   --body "$(cat <<'EOF'
 <!-- shiplog:
@@ -104,6 +105,7 @@ EOF
 ```
 
 On PowerShell, prefer the `--body-file` temp-file pattern from `references/shell-portability.md` instead of translating the heredoc inline.
+Before the first labeled create in a repository, run the bootstrap commands from `references/labels.md`.
 
 ---
 
@@ -220,6 +222,9 @@ git checkout -b <branch>--log
 git commit --allow-empty -m "shiplog: initialize knowledge log"
 git push -u origin <branch>--log
 gh pr create --base <branch> \
+  --label "shiplog/worklog" \
+  --label "shiplog/quiet-mode" \
+  --label "shiplog/issue-driven" \
   --title "[shiplog/worklog] <description>" \
   --body "<!-- shiplog:\nkind: state\nissue: <ISSUE_NUMBER>\nbranch: <branch>--log\nstatus: open\nupdated_at: <ISO_TIMESTAMP>\n-->\n\n## Knowledge Log\n\nTracking decisions and discoveries for this work."
 # If you deferred a brainstorm from PHASE 1, use that saved content as the initial PR body instead of this placeholder.
@@ -247,6 +252,8 @@ updated_at: <ISO_TIMESTAMP>
 
 ```bash
 gh issue create \
+  --label "shiplog/discovery" \
+  --label "shiplog/stacked" \
   --title "[shiplog/discovery] Brief description" \
   --body "$(cat <<'EOF'
 <!-- shiplog:
@@ -289,6 +296,11 @@ updated_at: <ISO_TIMESTAMP>
 -->
 
 [shiplog/discovery] #<PARENT>: Found sub-problem -> created #<NEW_ISSUE>. This is a stacked prerequisite."
+```
+
+Then mark the parent as blocked:
+```bash
+gh issue edit <PARENT_ISSUE> --add-label "shiplog/blocker"
 ```
 
 ---
@@ -377,6 +389,8 @@ ISSUE_NUMBER=<N>
 BASE_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
 
 gh pr create --base $BASE_BRANCH \
+  --label "shiplog/history" \
+  --label "shiplog/issue-driven" \
   --title "<type>(#$ISSUE_NUMBER): Brief description" \
   --body "$(cat <<'EOF'
 <!-- shiplog:

--- a/utils/edit-file.ps1
+++ b/utils/edit-file.ps1
@@ -1,0 +1,75 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$Path,
+
+  [string]$ReplaceExact,
+  [string]$With,
+  [string]$InsertAfter,
+  [string]$Text,
+  [string]$InsertBefore,
+  [string]$TextBefore,
+  [string]$EnsureContains
+)
+
+$fullPath = [System.IO.Path]::GetFullPath($Path)
+$content = [System.IO.File]::ReadAllText($fullPath)
+$newline = if ($content.Contains("`r`n")) { "`r`n" } elseif ($content.Contains("`n")) { "`n" } else { [Environment]::NewLine }
+$modeCount = 0
+
+if ($PSBoundParameters.ContainsKey('ReplaceExact')) { $modeCount++ }
+if ($PSBoundParameters.ContainsKey('InsertAfter')) { $modeCount++ }
+if ($PSBoundParameters.ContainsKey('InsertBefore')) { $modeCount++ }
+if ($PSBoundParameters.ContainsKey('EnsureContains')) { $modeCount++ }
+
+if ($modeCount -ne 1) {
+  throw 'Choose exactly one edit mode: ReplaceExact, InsertAfter, InsertBefore, or EnsureContains.'
+}
+
+if ($PSBoundParameters.ContainsKey('ReplaceExact')) {
+  if (-not $PSBoundParameters.ContainsKey('With')) {
+    throw 'ReplaceExact requires -With.'
+  }
+
+  if (-not $content.Contains($ReplaceExact)) {
+    throw 'ReplaceExact target not found.'
+  }
+
+  $updated = $content.Replace($ReplaceExact, $With)
+}
+elseif ($PSBoundParameters.ContainsKey('InsertAfter')) {
+  if (-not $PSBoundParameters.ContainsKey('Text')) {
+    throw 'InsertAfter requires -Text.'
+  }
+
+  $index = $content.IndexOf($InsertAfter)
+  if ($index -lt 0) {
+    throw 'InsertAfter marker not found.'
+  }
+
+  $insertAt = $index + $InsertAfter.Length
+  $updated = $content.Insert($insertAt, $Text)
+}
+elseif ($PSBoundParameters.ContainsKey('InsertBefore')) {
+  if (-not $PSBoundParameters.ContainsKey('TextBefore')) {
+    throw 'InsertBefore requires -TextBefore.'
+  }
+
+  $index = $content.IndexOf($InsertBefore)
+  if ($index -lt 0) {
+    throw 'InsertBefore marker not found.'
+  }
+
+  $updated = $content.Insert($index, $TextBefore)
+}
+else {
+  if ($content.Contains($EnsureContains)) {
+    $updated = $content
+  }
+  else {
+    $separator = if ($content.EndsWith($newline) -or [string]::IsNullOrEmpty($content)) { '' } else { $newline }
+    $updated = $content + $separator + $EnsureContains
+  }
+}
+
+$encoding = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($fullPath, $updated, $encoding)


### PR DESCRIPTION
﻿<!-- shiplog:
kind: history
issue: 85
branch: issue/85-shiplog-github-labels
status: resolved
updated_at: 2026-03-15T09:08:00Z
-->

## Summary

This PR teaches Shiplog to manage GitHub labels as part of the skill itself. It adds a canonical `shiplog/` label vocabulary, wires those labels into issue and PR creation templates, and documents the behavior in the README.

Closes #85

## Journey Timeline

### Initial Plan
Backfill a tracking issue for the already-started work, bootstrap the Shiplog labels in the repository, and then land the skill, template, and README changes under a standard Shiplog issue branch.

### What We Discovered
- The original request was about repository labels, while historical issue #14 only covered human-facing `[shiplog/<kind>]` title tags.
- `apply_patch` was still unreliable on existing markdown files in this Windows session, so a deterministic edit helper became part of the implementation.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Label ownership | Manage labels in the skill | The behavior should travel with Shiplog across repos rather than depend on per-repo GitHub Actions |
| Label scope | Keep a compact `shiplog/` namespace | Workflow labels are portable and avoid repo-specific taxonomy sprawl |
| Windows edit fallback | Add `utils/edit-file.ps1` | Deterministic exact-replace and marker-insert operations are safer after repeated patch failures |

### Changes Made

**Commits:**
- `085737b` feat(#85): add shiplog-managed labels

## Testing

**Verification summary:** inspected the diffs and validated the intended workflow changes in the skill and templates. No automated validator or test suite was run for this documentation-and-template change.

## Stacked PRs / Related

- None

## Knowledge for Future Reference

Shiplog now depends on label bootstrap as part of first-write repo setup. On Windows, if `apply_patch` misbehaves on existing markdown files, use the deterministic `utils/edit-file.ps1` helper instead of looping on failed patch attempts.

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
*Captain's log — PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
