### PR TITLE
docs(#87): prioritize npx skills install path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,9 +290,10 @@ Branches are created in git worktrees by default — one branch, one worktree, o
 
 ## Install
 
-### 1. Cross-platform with `npx skills add`
+### 1. Recommended: install and update with `npx skills`
 
-The fastest verified install path is the Vercel Labs CLI:
+The best default path is the Vercel Labs CLI because it covers Claude Code,
+Codex, and Cursor with one install flow and one update command:
 
 ```bash
 npx skills add devallibus/shiplog --skill shiplog
@@ -306,13 +307,18 @@ npx skills add devallibus/shiplog --skill shiplog --agent codex
 npx skills add devallibus/shiplog --skill shiplog --agent cursor
 ```
 
-Update later with:
+Keep the installed skill current with:
 
 ```bash
 npx skills update
 ```
 
-### 2. Claude Code plugin from a local checkout
+### 2. Fallback install methods
+
+Use these if you specifically want a Claude-only local plugin workflow or do
+not want to use `npx skills`.
+
+#### Claude Code plugin from a local checkout
 
 This repo includes a Claude plugin manifest in `.claude-plugin/plugin.json`.
 To validate and load it from a checkout:
@@ -322,7 +328,7 @@ claude plugins validate .claude-plugin/plugin.json
 claude --plugin-dir .
 ```
 
-### 3. Claude Code skill copy
+#### Claude Code skill copy
 
 If you want the raw skill without the plugin wrapper, copy `skills/shiplog/`
 into Claude Code's skill directory:
@@ -338,11 +344,10 @@ cp -r skills/shiplog .claude/skills/shiplog
 Then invoke with `/shiplog` or let it auto-activate when you create branches,
 issues, or PRs.
 
-### 4. Cursor and generic manual copy
+#### Generic manual copy for Codex, Cursor, and similar tools
 
 If you are not using the `npx skills` flow, you can still install shiplog by
-copying the skill folder into the generic agentskills.io layout used by Codex,
-Cursor, and similar tools:
+copying the skill folder into the generic agentskills.io layout:
 
 ```bash
 cp -r skills/shiplog .agents/skills/shiplog


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 87
branch: issue/87-readme-install-priority
status: resolved
updated_at: 2026-03-15T08:00:00Z
-->

## Summary

This PR restructures the README install section so the cross-platform `npx skills` flow is the default path instead of just one option among several. The update command now sits directly next to the primary install instructions, while Claude-specific and manual copy methods remain available as fallbacks lower in the section.

Closes #87

## Journey Timeline

### Initial Plan
Issue #87 was created to make the README match the real maintenance story for users who want shiplog installed across Claude Code, Codex, and Cursor and kept up to date with one command.

### What We Discovered
- The repo already documented the correct cross-tool install and update commands; the problem was prominence, not capability.
- The cleanest fix was a hierarchy change inside the existing install section, not any packaging or command change.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Primary install path | Lead with `npx skills add` and `npx skills update` | This is the only documented path that spans Claude Code, Codex, and Cursor with one update flow |
| Tool-specific methods | Keep them as fallback subsections | They remain useful, but they should not compete with the cross-platform default |

### Changes Made

**Commits:**
- `d175983` docs(#87): prioritize npx skills install path in README

## Testing

- [x] Reviewed the install section order in `README.md`
- [x] Confirmed `npx skills add` and `npx skills update` now appear first
- [x] Confirmed the Claude plugin, raw Claude skill copy, and generic `.agents/skills/shiplog` fallback methods remain documented

**Verification summary:** source-level documentation review only; no runtime behavior changed

## Stacked PRs / Related

- None

## Knowledge for Future Reference

When the repo offers multiple install paths, the README should lead with the one that best matches ongoing maintenance, not the most packaging-specific option. For shiplog today, that means `npx skills` first and agent-specific/manual methods second.

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
