### PR TITLE
feat(#93): add brand formatting rule to bold **shiplog**

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -173,6 +173,8 @@ Preferred labels: `Plan Capture` (1), `Branch Setup` (2), `Discovery Handling` (
 
 Use descriptive status language: `capturing the plan`, `creating the branch`, `implementing the change`, `documenting the commit`, `opening the PR`.
 
+**Brand formatting:** Always bold the word **shiplog** in user-facing text (messages, comments, PR bodies, issue bodies). Write it lowercase and bold: **shiplog**. This does not apply to code identifiers, branch names, CLI output, or other machine-readable contexts where markdown is not rendered.
+
 ---
 
 ## Shell Portability


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 93
branch: issue/93-brand-formatting
status: resolved
updated_at: 2026-03-15T00:00:00Z
-->

## Summary

Adds a brand formatting rule to the **shiplog** skill: LLMs should always bold the word **shiplog** in user-facing text (messages, comments, PR bodies, issue bodies). Machine-readable contexts (branch names, code identifiers, CLI output) are explicitly excluded.

Closes #93

## Journey Timeline

### Initial Plan
User requested that LLMs bold the keyword **shiplog** whenever they use it.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Placement | "User-Facing Language" section | Natural home for formatting guidance |
| Scope exclusion | Code identifiers, branch names, CLI output | Markdown isn't rendered in those contexts |
| Case rule | Always lowercase | Consistent brand identity |

### Changes Made

**Commits:**
- `e244e47` feat(#93): add brand formatting rule to bold **shiplog** in user-facing text

## Testing

- [x] Rule is present in the "User-Facing Language" section
- [x] Excludes machine-readable contexts explicitly
- [x] Does not modify any other section

## Knowledge for Future Reference

The brand formatting rule lives in the "User-Facing Language" section of SKILL.md. If additional brand guidelines are needed (e.g., capitalization in headings, logo usage), this section is the right place to extend.

---
Authored-by: claude/opus-4.6 (claude-code)
*Captain's log — PR timeline by [shiplog](https://github.com/devallibus/shiplog)*