### PR TITLE
docs(#95): mandate durable capture of implementation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ Discovery made during work
 
 Stacked prerequisites get their own issue and branch with cross-references on the parent. Nothing gets lost.
 
+### Implementation issue capture
+
+Implementation trouble that materially affects the work, including failed attempts, hidden dependencies, risky workarounds, scope surprises, and verification gaps, must be recorded durably before the agent moves on.
+
+| Situation | Action |
+|-----------|--------|
+| Resolved inline | Post a `[shiplog/implementation-issue]` timeline comment |
+| Warrants follow-up or long-term retrieval | Open a new linked issue |
+
+Reviewers treat uncaptured implementation issues as a workflow defect, because otherwise that knowledge stays trapped in chat-only memory.
+
 ### Task-level delivery
 
 Ship incrementally. Commits reference tasks (`feat(#42/T1): add JWT validation`), partial-delivery PRs use `Addresses #42 (completes T1, T2)`, and the issue stays open for remaining work. No premature closures, no lost track.
@@ -147,6 +158,8 @@ gh pr list --search "#42" --state all       # PRs
 git log --all --oneline --grep="#42"         # commits
 git log --all --oneline --grep="#42/T1"     # task-level commits
 ```
+
+Timeline comments use semantic tags such as `plan`, `session-start`, `session-resume`, `commit-note`, `discovery`, `implementation-issue`, `milestone`, `approach-change`, `blocker`, `review-handoff`, `worklog`, `history`, and `session-end`.
 
 ### GitHub labels
 

--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -109,7 +109,7 @@ See `references/model-routing.md` for routing prompt format, handoff template, a
 
 All artifacts use `#ID` as the primary key for fast, token-efficient retrieval.
 
-**Semantic tag vocabulary** for user-facing headings: `plan`, `session-start`, `commit-note`, `discovery`, `blocker`, `review-handoff`, `worklog`, `history`, `amendment`. Format: `[shiplog/<kind>] <human title>`.
+**Semantic tag vocabulary** for user-facing headings: `plan`, `session-start`, `commit-note`, `discovery`, `blocker`, `implementation-issue`, `review-handoff`, `worklog`, `history`, `amendment`. Format: `[shiplog/<kind>] <human title>`.
 
 | Artifact | Convention | Example |
 |----------|-----------|---------|
@@ -278,6 +278,42 @@ Discovery made during work
 **Phase 3a (stack a prerequisite):** Commit current progress. Create a new issue first (so the ID exists), then create the stacked branch. Label the new issue `shiplog/discovery` and `shiplog/stacked`. Cross-reference on the parent issue and add `shiplog/blocker` to the parent while it is blocked. See `references/phase-templates.md` for the discovery issue template. Sign both the discovery issue and the parent cross-reference comment per [Agent identity signing](#agent-identity-signing).
 
 **Phase 3b (independent discovery):** Create new issue (same template without "blocks parent") and label it `shiplog/discovery`. Add timeline comment. Continue current work. Sign each posted artifact per [Agent identity signing](#agent-identity-signing).
+
+---
+
+## Mandatory Issue Capture
+
+Implementation trouble that materially affects the work must be durably recorded before the agent proceeds to the next material step or ends the turn. This extends the Discovery Protocol — Phase 3 handles pre-identified sub-problems; this rule covers implementation friction that surfaces during execution.
+
+### What counts as a relevant implementation issue
+
+- **Failed attempts:** An approach that was tried and abandoned, even if a working alternative was found.
+- **Hidden dependencies:** Requirements or coupling not visible from the plan or task contract.
+- **Risky workarounds:** Temporary fixes, known-fragile code paths, or deliberate tech debt.
+- **Scope surprises:** Work that turned out larger, smaller, or different than the task described.
+- **Verification gaps:** Tests that could not be written, checks that were skipped, or coverage blind spots.
+- **Environment or tooling friction:** Build failures, dependency conflicts, or platform quirks that affected the implementation path.
+
+### What does NOT require capture
+
+- Normal iteration (try, adjust, succeed) where the final approach is obvious from the diff.
+- Minor typos or lint fixes resolved in the same commit.
+- Expected complexity that matches the task description.
+
+### Capture rule
+
+When a relevant implementation issue occurs, the agent must create a durable artifact **before** proceeding to the next material step or ending the turn:
+
+| Situation | Artifact | Where |
+|-----------|----------|-------|
+| Issue is local and resolved inline | Timeline comment (`[shiplog/implementation-issue]`) | Issue (Full Mode) or `--log` PR (Quiet Mode) |
+| Issue warrants follow-up, scope split, or long-term retrieval | New linked issue | GitHub issue with cross-reference on parent |
+
+The timeline comment is the minimum — one paragraph explaining what happened, why it matters, and how it was resolved (or why it was deferred). The linked issue follows the Phase 3b template when the implementation issue is independent, or Phase 3a when it blocks current work.
+
+### Why mandatory
+
+Chat-only knowledge is the failure mode this rule prevents. An implementation issue that exists only in the conversation context will be invisible to future agents, reviewers, and the project timeline. The "nothing gets lost" principle requires that knowledge threatening to get lost is captured at the moment it appears, not after the session ends.
 
 ---
 

--- a/skills/shiplog/references/closure-and-review.md
+++ b/skills/shiplog/references/closure-and-review.md
@@ -244,6 +244,7 @@ If spawning is unavailable, generate a self-contained review contract for the us
 - [ ] No unintended side effects or regressions
 - [ ] Cross-references between files are consistent
 - [ ] Templates and examples are correct
+- [ ] Relevant implementation issues are durably captured (timeline comments or linked issues) — not trapped in chat-only memory
 
 ### Output required
 Sign-off comment with:
@@ -305,6 +306,12 @@ A PR may be merged when:
 2. All `request-changes` reviews have been addressed (new review cycle or author response).
 3. The PR body includes `Closes #<N>` linking to the tracking issue.
 4. The issue closure will have linked evidence (the merged PR itself serves as evidence).
+
+### Implementation issue capture check
+
+As part of every review, the reviewer must check whether relevant implementation issues (failed attempts, hidden dependencies, workarounds, scope surprises, verification gaps) are durably captured as timeline comments or linked issues. If the PR timeline or commit history suggests implementation friction that is not captured in any durable artifact, the reviewer should request changes with a note explaining what needs to be recorded.
+
+This is a workflow completeness check, not a code quality check. The reviewer is not evaluating whether the implementation approach was correct — only whether knowledge that would otherwise be lost has been persisted.
 
 ### Risk-based review requirements
 

--- a/skills/shiplog/references/phase-templates.md
+++ b/skills/shiplog/references/phase-templates.md
@@ -426,6 +426,9 @@ Closes #<ISSUE_NUMBER>
 - [Discovery 1: what surprised us]
 - [Discovery 2: what we learned]
 
+### Implementation Issues
+- [Issue 1: what happened, how it was resolved — or "None"]
+
 ### Key Decisions Made
 
 | Decision | Choice | Why |
@@ -610,9 +613,43 @@ Tag-to-kind mapping:
 - `session-resume` -> `state`
 - `milestone` -> `state`
 - `discovery` -> `blocker`
+- `implementation-issue` -> `state`
 - `approach-change` -> `state`
 - `blocker` -> `blocker`
 - `session-end` -> `history`
+
+---
+
+## Implementation-Issue Timeline Comment
+
+Use this when a relevant implementation issue surfaces during execution and is
+resolved inline. Post on the tracked issue (Full Mode) or `--log` PR (Quiet Mode).
+See `SKILL.md` § Mandatory Issue Capture for the decision rule on when to use
+this comment vs. opening a new linked issue.
+
+```markdown
+<!-- shiplog:
+kind: state
+issue: <ID>
+updated_at: <ISO_TIMESTAMP>
+-->
+
+## [shiplog/implementation-issue] #<ID>: <brief summary>
+
+**Category:** failed attempt | hidden dependency | risky workaround | scope surprise | verification gap | tooling friction
+**Severity:** blocking (work stopped) | material (changed approach) | informational (worth recording)
+
+**What happened:**
+[1-3 sentences: what went wrong or what was unexpected]
+
+**Resolution:**
+[How it was handled — fix applied, workaround accepted, deferred to #<N>, or still open]
+
+**Impact on the work:**
+[How this affected scope, timeline, approach, or confidence in the result]
+
+Authored-by: <family>/<version> (<tool>)
+```
 
 ---
 


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 95
branch: issue/95-mandatory-issue-capture
status: resolved
updated_at: 2026-03-15T10:45:26Z
updated_by: openai/gpt-5.4 (cursor)
edit_kind: amendment
-->

## Summary

Adds mandatory issue-capture policy to **shiplog** so implementation-time friction - failed attempts, hidden dependencies, workarounds, scope surprises, verification gaps - becomes a first-class durable artifact rather than chat-only knowledge that future agents and reviewers cannot find.

Closes #95

## Journey Timeline

### Initial Plan
Issue #95 (authored by Codex) identified the gap: **shiplog** captures discoveries and blockers but does not mandate durable recording of implementation trouble that materially affects the work.

### What We Discovered
- The existing Discovery Protocol (Phase 3) cleanly covers pre-identified sub-problems but not inline-resolved implementation friction
- The implementation-issue tag fits naturally into the existing tag vocabulary and tag-to-kind mapping without requiring a new envelope kind
- README.md had moved to a newer install-first structure on master, so the rebase had to preserve that layout and reapply the implementation-issue guidance in the right sections instead of restoring the older README shape

### Implementation Issues
- Rebased onto current master and resolved the README.md conflict by keeping the newer install/config structure and reapplying the implementation-issue additions.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Placement of policy | New section between Phase 3 and Phase 4 | Conceptually extends the Discovery Protocol; applies during execution phases |
| Comment vs. issue decision rule | Comment for inline-resolved; issue for follow-up/scope-split/retrieval | Matches the existing Phase 3a/3b pattern without adding overhead |
| Envelope kind for template | state (latest-wins) | Implementation issues are status snapshots, not accumulating events |
| Review enforcement level | Workflow defect (request-changes) | Strong enough to matter; review already checks for durable artifacts |

### Changes Made

**Commits:**
- 4b6a412 docs(#95): mandate durable capture of implementation issues

## Testing

- [x] Mandatory Issue Capture section is present in SKILL.md between Phase 3 and Phase 4
- [x] implementation-issue tag added to semantic tag vocabulary in SKILL.md and README
- [x] Timeline comment template added to phase-templates.md with category and severity fields
- [x] Tag-to-kind mapping includes implementation-issue -> state
- [x] PR timeline template includes "Implementation Issues" subsection
- [x] Review contract checklist includes implementation-issue capture check
- [x] Merge conditions section includes implementation issue capture check subsection
- [x] README Discovery Protocol, Implementation issue capture, and ID-first tag guidance updated on top of the current README structure
- [x] No existing sections modified beyond adding the new policy and related terminology updates

## Knowledge for Future Reference

The mandatory issue capture rule lives between Phase 3 (Discovery Protocol) and Phase 4 (Commit-with-Context) in SKILL.md. If future work adds more cross-cutting policies, this area between the phases is the natural home. The implementation-issue tag uses state as its envelope kind (latest-wins), which means if multiple implementation issues occur on the same issue, each gets its own timeline comment - they accumulate as separate state snapshots, not a single latest-wins artifact.

---
Authored-by: claude/opus-4.6 (claude-code)
Updated-by: openai/gpt-5.4 (cursor)
Edit-kind: amendment
Edit-note: Rebased onto current master, corrected the commit reference, and updated the README notes to match the reconciled diff.
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
