### PR TITLE
feat(#97): add self-audit verification profile

### DIFF
--- a/skills/shiplog/references/phase-templates.md
+++ b/skills/shiplog/references/phase-templates.md
@@ -339,6 +339,8 @@ updated_at: <ISO_TIMESTAMP>
 - **Scenarios:** [added N, changed M, existing passed K]
 - **Tests:** [added N, changed M, all passing]
 - **Deferred:** [anything intentionally skipped, with reason]
+[If self-audit profile active]:
+- **Self-audit:** clean | N findings fixed | not applicable (reason)
 
 **Discovered:** [Anything unexpected, or "Nothing unexpected"]
 
@@ -376,6 +378,8 @@ updated_at: <ISO_TIMESTAMP>
 - **Scenarios:** [added N, changed M, existing passed K]
 - **Tests:** [added N, changed M, all passing]
 - **Deferred:** [anything intentionally skipped, with reason]
+[If self-audit profile active]:
+- **Self-audit:** clean | N findings fixed | not applicable (reason)
 
 **Discovered:** [Anything unexpected, or "Nothing unexpected"]
 
@@ -442,6 +446,7 @@ Closes #<ISSUE_NUMBER>
 - [x] [What was tested and how]
 - [x] All existing tests pass
 - [x] [Verification-profile-specific checks, e.g., "Fail-first confirmed", "No existing scenarios modified"]
+- [x] Self-audit: implementation reviewed for redundancy, dead code, and simplification opportunities
 
 **Verification summary:** [scenarios added/changed, tests added/changed, deferred items]
 

--- a/skills/shiplog/references/verification-profiles.md
+++ b/skills/shiplog/references/verification-profiles.md
@@ -20,6 +20,7 @@ Configurable testing and semantic-stability profiles for shiplog. Verification i
 | `none` | No verification requirements | silent |
 | `behavior-spec` | Acceptance scenarios for new/changed behavior | per-issue opt-in |
 | `red-green` | Fail-first unit tests for changed behavior | per-issue opt-in |
+| `self-audit` | Implementation quality self-review before commit | per-issue opt-in |
 | `structural` | Structural quality analysis on changed modules | per-issue opt-in |
 | `mutation` | Differential mutation testing on changed modules | strict-profile opt-in |
 
@@ -58,6 +59,9 @@ behavior-spec, red-green
 
 ### red-green
 - fail_first_evidence: true
+
+### self-audit
+- on_finding: fix-before-proceed
 
 ### structural
 - threshold: crap <= 8
@@ -205,6 +209,7 @@ Add to the Phase 5 PR timeline Testing section:
 | Test results summary | Every commit with test changes | Commit comment |
 | Existing scenarios modified | Always — this is a change signal | Commit comment + issue timeline |
 | Deferred verification | When something was intentionally skipped | Commit comment, PR body |
+| Self-audit findings | When self-audit is active | Commit comment |
 | Structural analysis results | When structural profile is active | PR body |
 | Mutation results | When mutation profile is active | PR body |
 
@@ -221,7 +226,74 @@ This makes behavior drift traceable. If a reviewer sees modified scenarios witho
 
 ---
 
-## 5. Structural and Mutation Gates
+## 5. Self-Audit Protocol
+
+The `self-audit` profile requires the agent to review its own diff for implementation quality issues before committing. This catches redundancy, dead code, and missed simplifications before they reach the cross-model review gate.
+
+### Scope
+
+Only files changed in the current branch compared to the base branch — the same scoping as `structural`.
+
+### Review checklist
+
+The agent reviews its diff against these questions:
+
+1. **Simpler approach?** Is there a better or simpler way to achieve the same result?
+2. **Redundant code?** Does any redundant code remain — copy-pasted blocks, near-duplicate logic?
+3. **Duplicate logic?** Was logic introduced that could reuse an existing function or utility in the codebase?
+4. **Dead code?** Is there dead or unused code left behind — unreachable branches, unused imports, orphaned helpers?
+
+If findings exist, the agent acts according to the `on_finding` setting. If no issues are found, the agent briefly confirms the implementation is clean and proceeds.
+
+### Configuration
+
+```markdown
+### self-audit
+- on_finding: fix-before-proceed | warn | log
+```
+
+| `on_finding` | Behavior |
+|--------------|----------|
+| `fix-before-proceed` | Agent must fix issues before committing (default) |
+| `warn` | Log findings in the commit context, continue |
+| `log` | Record silently in verification evidence |
+
+**Default:** `fix-before-proceed` — issues are resolved inline before the commit happens.
+
+### Execution order
+
+When composed with other profiles, `self-audit` runs **first** — fix quality issues before verifying behavior. A clean implementation produces more meaningful test results.
+
+```
+self-audit → behavior-spec → red-green → structural → mutation
+```
+
+### When not applicable
+
+Documentation-only, config-only, or template-only changes may not benefit from self-audit. In this case:
+
+- Log `Self-audit: not applicable (docs-only change)` in the commit context.
+- The profile does not block — it just requires the exemption to be explicit.
+
+### Self-audit evidence
+
+In the commit context:
+
+```markdown
+- **Self-audit:** clean | N findings fixed | not applicable (reason)
+```
+
+When `on_finding` is `warn` or `log`, include the findings:
+
+```markdown
+- **Self-audit:** 2 findings (warn)
+  - Unused import `parseConfig` in `src/auth.ts`
+  - Near-duplicate validation logic in `handleLogin` / `handleRegister`
+```
+
+---
+
+## 6. Structural and Mutation Gates
 
 ### Structural analysis
 


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 97
branch: issue/97-self-audit-profile
status: resolved
updated_at: 2026-03-15T12:20:00Z
-->

## Summary

Adds a composable `self-audit` verification profile that requires agents to review their own diff for implementation quality issues before committing. Fills the gap between "implementation done" and the cross-model review gate.

Closes #97

## Journey Timeline

### Initial Plan
User shared a self-review prompt and asked whether it could be integrated into shiplog. We identified that verification profiles cover testing evidence but lack an implementation quality self-review step. The `self-audit` profile was the most shiplog-native integration point — composable, opt-in, consistent with existing patterns.

### What We Discovered
- The existing profile system already handles composition, configuration, and evidence logging — no new infrastructure needed
- Phase 4 in SKILL.md already routes generically to verification profiles, so no SKILL.md changes required

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Integration approach | New verification profile (not baked into Phase 4) | Composable, opt-in, consistent with existing patterns |
| Default `on_finding` | `fix-before-proceed` | Self-audit's value is fixing issues before they reach review, not just logging them |
| Execution order | Self-audit runs first in composition chain | Clean code produces more meaningful test results |

### Changes Made

**Commits:**
- `8f76cd9` feat(#97): add self-audit verification profile

**Files:**
- `skills/shiplog/references/verification-profiles.md` — Added `self-audit` to taxonomy table, config example, evidence table; new §5 Self-Audit Protocol (scope, checklist, config, evidence); renumbered old §5 → §6
- `skills/shiplog/references/phase-templates.md` — Added self-audit evidence to Bash and PowerShell commit-context templates; added self-audit checklist item to PR Testing section

## Testing

- [x] Read both modified files end-to-end after changes
- [x] Taxonomy table has `self-audit` in correct alphabetical position
- [x] Section numbering is consistent (§5 Self-Audit, §6 Structural and Mutation)
- [x] No duplication with `structural` profile (complexity metrics vs implementation quality)
- [x] Self-audit evidence appears in both Bash and PowerShell commit-context templates
- [x] PR Testing section includes self-audit checklist item

## Knowledge for Future Reference

- The `self-audit` profile is intentionally lightweight — it defines a checklist and evidence policy, not tooling. This follows the same "policy not tooling" design principle as all other profiles.
- Execution order (`self-audit → behavior-spec → red-green → structural → mutation`) is documented in the protocol section. Future profiles should consider where they fit in this chain.

---
Authored-by: claude/opus-4.6 (claude-code)
*Captain's log — PR timeline by [shiplog](https://github.com/devallibus/shiplog)*