### PR TITLE
feat(#108): add slash commands for explicit shiplog phase entry points

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
   "homepage": "https://github.com/devallibus/shiplog",
   "repository": "https://github.com/devallibus/shiplog",
   "license": "MIT",
-  "skills": "./skills/"
+  "skills": "./skills/",
+  "commands": "./commands/"
 }

--- a/README.md
+++ b/README.md
@@ -237,6 +237,35 @@ For local iteration without reinstalling after every change.
 - `git` — in a repo with a GitHub remote
 - That's it. Everything else is optional.
 
+## Slash Commands
+
+Invoke specific **shiplog** operations directly instead of loading the full skill:
+
+| Command | What It Does |
+|---------|-------------|
+| `/shiplog hunt` | Scan open issues and PRs, rank by readiness, recommend what to work on next |
+| `/shiplog plan <description>` | Brainstorm a feature and capture it as a GitHub Issue (Phase 1) |
+| `/shiplog start <issue-number>` | Create a branch and worktree from an issue, start a work session (Phase 2) |
+| `/shiplog commit` | Commit with ID-first convention and optional context comment (Phase 4) |
+| `/shiplog pr` | Create a PR with a journey timeline body (Phase 5) |
+| `/shiplog lookup <query>` | Search across issues, PRs, commits, and memory (Phase 6) |
+| `/shiplog models` | Configure model-tier routing for phase transitions |
+| `/shiplog resume` | Resume a work session on the current branch |
+
+Commands are lightweight entry points — each one gathers context and executes a focused workflow. The full `/shiplog` skill remains available for auto-activation.
+
+### Installing Commands
+
+Commands are installed automatically with the plugin. For manual installs, copy the commands directory:
+
+```bash
+# Global (all projects)
+cp -r commands/shiplog ~/.claude/commands/shiplog
+
+# Or project-local
+cp -r commands/shiplog .claude/commands/shiplog
+```
+
 ## Configuration
 
 | File | Purpose |

--- a/commands/shiplog/commit.md
+++ b/commands/shiplog/commit.md
@@ -1,0 +1,64 @@
+---
+allowed-tools: Bash(git:*), Bash(gh:*), Read
+description: Commit staged changes with shiplog ID-first convention and optional context comment
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Git status: !`git status`
+- Staged and unstaged changes: !`git diff HEAD`
+- Recent commits: !`git log --oneline -10`
+
+## Your Task
+
+You are executing shiplog Phase 4: Commit-with-Context.
+
+### Step 1: Extract the Issue Number
+
+Parse the issue number from the current branch name. Branch format: `issue/<number>-<slug>`.
+
+If the branch doesn't follow shiplog convention, ask the user for the issue number.
+
+### Step 2: Stage and Commit
+
+Based on the changes, create a commit with the shiplog ID-first format:
+
+```
+<type>(#<issue-number>): <description>
+```
+
+If the commit addresses a specific task from the issue, include the task ID:
+```
+<type>(#<issue-number>/<Tn>): <description>
+```
+
+**Commit types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `style`, `perf`.
+
+Stage relevant files (prefer specific files over `git add -A`). Create the commit. Do not use `--no-verify`.
+
+End the commit message with:
+```
+
+Co-Authored-By: <model family/version> (<tool>) <noreply@anthropic.com>
+```
+
+### Step 3: Context Comment (for significant commits)
+
+For significant changes (new functionality, unexpected discoveries, approach changes, tricky fixes), post a context comment on the issue:
+
+```
+[shiplog/commit-note] #<issue-number>: <commit-hash-short> <commit-subject>
+
+**What:** <1-2 sentences on what this commit does>
+**Why:** <reasoning behind the approach>
+**Verification:** <what was tested or checked>
+
+Authored-by: <model-family>/<model-version> (<tool>)
+```
+
+Skip the context comment for trivial commits (typos, formatting, small fixes).
+
+### Step 4: Report
+
+Show the user the commit hash, message, and files changed.

--- a/commands/shiplog/hunt.md
+++ b/commands/shiplog/hunt.md
@@ -1,0 +1,68 @@
+---
+allowed-tools: Bash(gh:*), Bash(git:*), Read
+description: Scan open issues and PRs, rank by readiness, recommend what to work on next
+---
+
+## Context
+
+- Repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner'`
+- Current branch: !`git branch --show-current`
+- Open issues with labels: !`gh issue list --state open --json number,title,labels --limit 30`
+- Open PRs with review status: !`gh pr list --state open --json number,title,reviewDecision,reviews,isDraft --limit 20`
+
+## Your Task
+
+You are the shiplog hunt command. Present a triage report of all open issues and PRs.
+
+### Step 1: Categorize Issues
+
+Group open issues by their lifecycle label:
+
+| Priority | Label | Meaning |
+|----------|-------|---------|
+| 1 (act now) | `shiplog/needs-review` | PR exists, needs cross-model review before merge |
+| 2 (act now) | `shiplog/ready` | Planned and ready to implement |
+| 3 (in flight) | `shiplog/in-progress` | Already being worked on |
+| 4 (needs planning) | `shiplog/plan` (no lifecycle label) | Needs further breakdown or review |
+| 5 (parked) | No shiplog labels | Uncategorized or external |
+
+### Step 2: Categorize PRs
+
+Group open PRs by review status:
+
+| Priority | Status | Action Needed |
+|----------|--------|---------------|
+| 1 | No reviews, not draft | Needs review — can we review and merge? |
+| 2 | Changes requested | Needs fixes then re-review |
+| 3 | Approved | Ready to merge |
+| 4 | Draft | Still in progress |
+
+### Step 3: Present the Hunt Report
+
+Display a compact table:
+
+```
+HUNT REPORT — <repo> (<date>)
+================================
+
+PRs NEEDING ACTION:
+#NNN  <title>                           <status>
+
+ISSUES READY TO IMPLEMENT:
+#NNN  <title>                           <labels>
+
+ISSUES IN PROGRESS:
+#NNN  <title>                           <labels>
+
+ISSUES NEEDING PLANNING:
+#NNN  <title>                           <labels>
+```
+
+### Step 4: Recommend
+
+End with 1-3 concrete recommendations:
+- Which PR to review next (if any need review)
+- Which issue to start implementing (highest-readiness first)
+- Any housekeeping (stale issues, PRs with no activity)
+
+Keep the report concise. The user wants to know what to do next, not read every issue body.

--- a/commands/shiplog/lookup.md
+++ b/commands/shiplog/lookup.md
@@ -1,0 +1,63 @@
+---
+allowed-tools: Bash(gh:*), Bash(git:*), Read
+description: Search the knowledge graph — issues, PRs, commits, and memory
+argument-hint: <search query>
+---
+
+## Context
+
+- Repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner'`
+- Current branch: !`git branch --show-current`
+
+## Your Task
+
+You are executing shiplog Phase 6: Knowledge Retrieval.
+
+**Search query:** $ARGUMENTS
+
+### Step 1: Search GitHub Issues and PRs
+
+```
+gh issue list --state all --search "$ARGUMENTS" --json number,title,state,labels --limit 10
+gh pr list --state all --search "$ARGUMENTS" --json number,title,state --limit 10
+```
+
+### Step 2: Search Git History
+
+```
+git log --all --oneline --grep="$ARGUMENTS" --limit 20
+```
+
+### Step 3: Search Knowledge Graph (if available)
+
+If `ork:memory` is available, search it:
+```
+/ork:memory search "$ARGUMENTS"
+```
+
+### Step 4: Compile Results
+
+Present a summary organized by source:
+
+```
+LOOKUP: "$ARGUMENTS"
+======================
+
+ISSUES:
+#NNN  <title>                    <state>  <labels>
+
+PULL REQUESTS:
+#NNN  <title>                    <state>
+
+COMMITS:
+<hash>  <subject>
+
+MEMORY:
+<key decisions or patterns found>
+```
+
+### Step 5: Deep Dive (if needed)
+
+If results are found, offer to read the most relevant issue or PR body for full context. Prefer reading envelope metadata first (look for `<!-- shiplog:` HTML comments) before loading full bodies.
+
+Keep the initial report concise. Let the user ask for details on specific items.

--- a/commands/shiplog/models.md
+++ b/commands/shiplog/models.md
@@ -1,0 +1,50 @@
+---
+allowed-tools: Bash(cat:*), Bash(test:*), Bash(mkdir:*), Read, Write
+description: Configure model-tier routing for shiplog phase transitions
+---
+
+## Context
+
+- Routing config exists: !`test -f .shiplog/routing.md && echo "yes" || echo "no"`
+- Current config: !`cat .shiplog/routing.md 2>/dev/null || echo "(no config file)"`
+
+## Your Task
+
+You are running the shiplog model-routing setup.
+
+### If Config Exists
+
+Show the current routing mode and ask if the user wants to change it.
+
+### If No Config Exists (or user wants to change)
+
+Present the setup prompt:
+
+> How should I handle model-tier suggestions at phase transitions?
+>
+> - **confirm** (default) -- I'll pause and ask before proceeding, so you can switch models if you want.
+> - **warn** -- I'll show a banner but keep going.
+> - **off** -- No routing prompts. Use this if you run the same model for everything.
+>
+> **Tier reference:**
+> | Tier | Use For | Example Phases |
+> |------|---------|----------------|
+> | tier-1 (reasoning) | Creative synthesis, architecture | Brainstorm, PR timeline |
+> | tier-2 (capable) | Context loading, structured docs | Issue-to-branch, retrieval |
+> | tier-3 (fast) | Execution, routine operations | Commits, timeline updates |
+
+### Save the Choice
+
+Create `.shiplog/routing.md`:
+
+```markdown
+# Model Routing
+
+routing: <chosen-mode>
+```
+
+Create the `.shiplog/` directory if it doesn't exist.
+
+### Report
+
+Confirm the saved routing mode and explain when it will take effect (at the next phase transition).

--- a/commands/shiplog/plan.md
+++ b/commands/shiplog/plan.md
@@ -1,0 +1,65 @@
+---
+allowed-tools: Bash(gh:*), Bash(git:*), Read, Write, Glob, Agent, Skill
+description: Brainstorm a feature and capture it as a GitHub Issue
+argument-hint: <feature description>
+---
+
+## Context
+
+- Repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner'`
+- Default branch: !`gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`
+- Existing labels: !`gh label list --json name --jq '.[].name' --limit 50`
+
+## Your Task
+
+You are executing shiplog Phase 1: Brainstorm-to-Issue.
+
+**Feature to plan:** $ARGUMENTS
+
+### Step 1: Brainstorm
+
+Run a focused brainstorm on the feature. Consider:
+- What problem does this solve and why now?
+- What are the key design decisions?
+- What alternatives exist?
+- What are the risks and open questions?
+
+If `superpowers:brainstorming` or `ork:brainstorming` is available, delegate to it. Otherwise brainstorm inline.
+
+### Step 2: Bootstrap Labels
+
+If the repo does not already have shiplog labels (`shiplog/plan`, `shiplog/ready`, etc.), bootstrap them:
+```
+gh label create "shiplog/plan" --color "0B7285" --description "Brainstorm captured as a planning issue" --force
+gh label create "shiplog/ready" --color "2DA44E" --description "Ready to implement" --force
+gh label create "shiplog/in-progress" --color "FBCA04" --description "Implementation in progress" --force
+gh label create "shiplog/needs-review" --color "D93F0B" --description "Awaiting review" --force
+gh label create "shiplog/discovery" --color "1D6F42" --description "Work discovered during another issue or PR" --force
+gh label create "shiplog/history" --color "5319E7" --description "PR with a shiplog journey timeline" --force
+gh label create "shiplog/issue-driven" --color "D4C5F9" --description "Branch/PR driven by an issue" --force
+```
+
+### Step 3: Create the Issue
+
+Create a GitHub issue using the shiplog Phase 1 template. The issue body must include:
+- An envelope comment (HTML comment with `kind: state`, `status: open`, `phase: 1`)
+- Context, Design Summary, Approach, Alternatives Considered
+- Tasks with tier tags (`[tier-1]`, `[tier-2]`, `[tier-3]`) and contract fields
+- Open Questions (if any)
+
+Apply the `shiplog/plan` label at creation time.
+
+Classify all factual claims as internal (verifiable from the repo) or external (needs primary source). Mark unverified external claims as `[unverified]`.
+
+### Step 4: Sign the Artifact
+
+End the issue body with:
+```
+Authored-by: <model-family>/<model-version> (<tool>)
+```
+
+Detect your model identity from the system prompt.
+
+### Step 5: Report
+
+Show the user the created issue number and URL. Ask if they want to start working on it (which would trigger Phase 2).

--- a/commands/shiplog/pr.md
+++ b/commands/shiplog/pr.md
@@ -1,0 +1,72 @@
+---
+allowed-tools: Bash(gh:*), Bash(git:*), Read, Write, Skill
+description: Create a PR with a shiplog journey timeline
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Default branch: !`gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`
+- Commit history on this branch: !`git log --oneline origin/HEAD..HEAD 2>/dev/null || git log --oneline -20`
+- Unpushed commits: !`git log --oneline @{upstream}..HEAD 2>/dev/null || echo "(no upstream set)"`
+
+## Your Task
+
+You are executing shiplog Phase 5: PR-as-Timeline.
+
+### Step 1: Extract Issue Number and Context
+
+Parse the issue number from the branch name (`issue/<number>-<slug>`).
+
+Fetch the issue:
+```
+gh issue view <number> --json title,body,labels,comments
+```
+
+Read the issue body for tasks, decisions, and context.
+
+### Step 2: Push the Branch
+
+If there are unpushed commits or no upstream:
+```
+git push -u origin <branch-name>
+```
+
+### Step 3: Build the PR Body
+
+Create the PR using the shiplog timeline template. The PR body must include:
+
+1. **Summary** — 1-3 bullet points
+2. **`Closes #<number>`** (or `Addresses #<number> (completes T1, T2, ...)` for partial delivery)
+3. **Journey Timeline** — Initial Plan, What We Discovered, Key Decisions Made (table), Changes Made (commits list)
+4. **Testing** — Checklist of what was verified
+5. **Knowledge for Future Reference** — Lessons learned
+
+Apply labels: `shiplog/history`, `shiplog/issue-driven`.
+
+### Step 4: Create the PR
+
+Use `gh pr create` with `--body-file` for the multiline body:
+```
+gh pr create --title "<type>(#<number>): <summary>" --body-file <temp-file> --label "shiplog/history" --label "shiplog/issue-driven"
+```
+
+### Step 5: Sign the Artifact
+
+End the PR body with:
+```
+---
+Authored-by: <model-family>/<model-version> (<tool>)
+*Captain's log -- PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
+```
+
+### Step 6: Update Issue Label
+
+Transition the issue to needs-review:
+```
+gh issue edit <number> --remove-label "shiplog/in-progress" --add-label "shiplog/needs-review"
+```
+
+### Step 7: Report
+
+Show the user the PR URL and remind them that cross-model review is required before merge.

--- a/commands/shiplog/resume.md
+++ b/commands/shiplog/resume.md
@@ -1,0 +1,64 @@
+---
+allowed-tools: Bash(gh:*), Bash(git:*), Read
+description: Resume a shiplog work session on the current branch
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Existing worktrees: !`git worktree list`
+- Recent commits on this branch: !`git log --oneline -10`
+- Uncommitted changes: !`git status --short`
+
+## Your Task
+
+You are resuming a shiplog work session (Phase 2 continuation + Phase 7 timeline update).
+
+### Step 1: Detect the Issue
+
+Parse the issue number from the current branch name (`issue/<number>-<slug>`).
+
+If the branch doesn't match the shiplog convention, check if there's a worktree with a shiplog branch and offer to switch to it.
+
+### Step 2: Load Issue Context
+
+```
+gh issue view <number> --json title,body,labels,comments
+```
+
+Read the issue body for:
+- Task list and completion status
+- Recent timeline comments (session starts, milestones, blockers)
+- Any open blockers
+
+Also check for linked PRs:
+```
+gh pr list --state open --head "issue/<number>-*" --json number,title,url
+```
+
+### Step 3: Post Session-Resume Comment
+
+Post a timeline comment on the issue:
+
+```
+[shiplog/session-resume] #<number>: Resuming work
+
+**Branch:** `<branch-name>`
+**Last commit:** `<hash> <subject>`
+**Uncommitted changes:** <yes/no + summary>
+**Tasks remaining:** <list of unchecked tasks>
+**Picking up from:** <brief summary of where we left off>
+
+Authored-by: <model-family>/<model-version> (<tool>)
+```
+
+### Step 4: Report
+
+Show the user:
+- Issue title and number
+- Tasks completed vs remaining
+- Any blockers from previous sessions
+- Recommended next task to work on
+- Any open PRs for this issue
+
+Keep it brief -- the user wants to get back to work quickly.

--- a/commands/shiplog/start.md
+++ b/commands/shiplog/start.md
@@ -1,0 +1,76 @@
+---
+allowed-tools: Bash(gh:*), Bash(git:*), Read, Write, Skill
+description: Create a branch and worktree from a GitHub issue, start a work session
+argument-hint: <issue-number>
+---
+
+## Context
+
+- Repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner'`
+- Current branch: !`git branch --show-current`
+- Default branch: !`gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`
+- Existing worktrees: !`git worktree list`
+
+## Your Task
+
+You are executing shiplog Phase 2: Issue-to-Branch.
+
+**Issue to start:** #$ARGUMENTS
+
+### Step 1: Load the Issue
+
+Fetch the full issue context:
+```
+gh issue view $ARGUMENTS --json title,body,labels,comments,milestone
+```
+
+Read the issue title, tasks, and any existing timeline comments.
+
+### Step 2: Create the Branch
+
+Derive the branch name from the issue: `issue/<number>-<brief-slug>`.
+
+Use a worktree (preferred) or in-place checkout:
+
+**Worktree (preferred):**
+```bash
+git fetch origin <default-branch>
+git worktree add ../<branch-name> -b <branch-name> origin/<default-branch>
+cd ../<branch-name>
+```
+
+If `superpowers:using-git-worktrees` is available, delegate to it instead.
+
+**Fallback (in-place):** Only if the user requests no worktree.
+```bash
+git fetch origin <default-branch>
+git checkout -b <branch-name> origin/<default-branch>
+```
+
+### Step 3: Update Issue Labels
+
+If the issue has `shiplog/plan` or `shiplog/ready` but not `shiplog/in-progress`, transition it:
+```
+gh issue edit $ARGUMENTS --remove-label "shiplog/ready" --add-label "shiplog/in-progress"
+```
+
+### Step 4: Post Session-Start Comment
+
+Post a timeline comment on the issue:
+```
+[shiplog/session-start] #<number>: Starting work
+
+**Branch:** `<branch-name>`
+**Worktree:** `<path>`
+**Starting tasks:** <list of tasks from issue body>
+**Plan:** <brief summary of approach>
+
+Authored-by: <model-family>/<model-version> (<tool>)
+```
+
+### Step 5: Report
+
+Tell the user:
+- The branch and worktree path created
+- A summary of the tasks from the issue
+- Which task to start with


### PR DESCRIPTION

## Summary

- Add 8 slash commands (`/shiplog hunt`, `/shiplog plan`, `/shiplog start`, `/shiplog commit`, `/shiplog pr`, `/shiplog lookup`, `/shiplog models`, `/shiplog resume`) so users can invoke specific **shiplog** operations without loading the full 28KB skill
- Register commands in plugin manifest and document in README

Closes #108

## Journey Timeline

### Initial Plan
User tried `/shiplog` to hunt for PRs/issues and discovered the skill was monolithic — no sub-commands. Other plugins (`commit-commands`, `spec`, `superpowers`) use Claude Code's `commands/` mechanism to provide focused slash sub-commands. **shiplog** needed the same.

### What We Discovered
- Claude Code has two mechanisms: **skills** (`skills/<name>/SKILL.md`) and **commands** (`commands/<dir>/<name>.md`)
- `spec:new`, `adr:adr`, etc. are commands at `~/.claude/commands/<dir>/<name>.md`
- Plugin commands (like `commit-commands:commit`) live in `<plugin>/commands/<name>.md` and are auto-discovered — no explicit `plugin.json` declaration needed
- The commit-commands plugin.json has no explicit commands field, but we added one to `plugin.json` for explicitness

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Location | `commands/shiplog/` at repo root | Auto-discovered by plugin loader; works for both plugin and manual installs |
| Naming | Phase-aligned (`hunt`, `plan`, `start`, `commit`, `pr`, `lookup`, `models`, `resume`) | Maps to shiplog phases; "hunt" chosen over "triage" for branding |
| Scope | Lightweight entry points, not full phase logic | Each command gathers context and guides the agent; SKILL.md stays the full reference |
| SKILL.md | No changes | Remains the auto-activation engine; commands are explicit entry points |

### Changes Made

**New files:**
- `commands/shiplog/hunt.md` — scan issues/PRs, rank by readiness
- `commands/shiplog/plan.md` — brainstorm → GitHub Issue (Phase 1)
- `commands/shiplog/start.md` — issue → branch + worktree (Phase 2)
- `commands/shiplog/commit.md` — commit with context (Phase 4)
- `commands/shiplog/pr.md` — PR with timeline body (Phase 5)
- `commands/shiplog/lookup.md` — knowledge retrieval (Phase 6)
- `commands/shiplog/models.md` — configure model routing
- `commands/shiplog/resume.md` — resume work session

**Modified files:**
- `.claude-plugin/plugin.json` — added `"commands": "./commands/"`
- `README.md` — added Slash Commands section with table and install instructions

**Commits:**
- `df94811` feat(#108): add slash commands for explicit shiplog phase entry points

## Testing

- [x] All 8 command files have proper YAML frontmatter (`allowed-tools`, `description`, `argument-hint`)
- [x] Commands installed to `~/.claude/commands/shiplog/` and confirmed visible in session skill list as `shiplog:hunt`, `shiplog:plan`, etc.
- [x] README Slash Commands section renders correctly with command table
- [x] plugin.json is valid JSON with commands field
- [x] Conflict with master README resolved cleanly (Slash Commands section inserted before Configuration)

## Knowledge for Future Reference

- Claude Code **commands** are `.md` files in `commands/<namespace>/<name>.md` — they appear as `namespace:name` in the skills list and are invoked as `/namespace name`
- Commands use `!` backtick syntax for inline context gathering (e.g., `` !`git status` ``)
- Plugin commands are auto-discovered from the `commands/` directory; the explicit `"commands"` field in plugin.json is optional but good practice
- The main SKILL.md skill and the commands directory coexist — skill for auto-activation, commands for explicit invocation

---
Authored-by: claude/opus-4.6 (claude-code)
*Captain's log — PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
