### PR TITLE
docs(#132): add PR-body review snapshot workflow

### DIFF
--- a/commands/shiplog/hunt.md
+++ b/commands/shiplog/hunt.md
@@ -54,21 +54,31 @@ Group open issues by their lifecycle label:
 
 Group open PRs by **shiplog** review status.
 
-For each open PR, inspect signed review artifacts in the PR body and comments by searching for:
+For each open PR, inspect the PR body review snapshot first by looking for:
+- `## Review Status`
+- `review_status:`
+- `Last reviewed by:`
+- `Last reviewed at:`
+- `Reviewed commit:`
+- `Source artifact:`
+- `Needs re-review since:`
+
+If the snapshot is missing, stale, or contradicted by newer code, inspect signed review artifacts in the PR comments by searching for:
 - `Reviewed-by:`
 - `Disposition: approve`
 - `Disposition: request-changes`
 
-Use `gh pr view <N> --json body,comments,reviewDecision,reviews` when the list output is not enough.
+Use `gh pr view <N> --json body,comments,reviewDecision,reviews,commits` when the list output is not enough.
 
-Treat signed **shiplog** review comments as the authoritative review signal. Formal GitHub `reviews` / `reviewDecision` fields are advisory only and must not override a signed `Reviewed-by:` comment artifact.
+Treat the PR body snapshot as the current summary, signed **shiplog** review comments as the evidence trail, and formal GitHub `reviews` / `reviewDecision` fields as advisory only.
 
 | Priority | Status | Action Needed |
 |----------|--------|---------------|
-| 1 | No signed review artifact, not draft | Needs first review |
-| 2 | Latest signed review is `request-changes` | Needs fixes then re-review |
-| 3 | Latest signed review is `approve` | Ready to merge if other gates are satisfied |
-| 4 | Draft | Still in progress |
+| 1 | `awaiting-review` or no review snapshot, not draft | Needs first review |
+| 2 | `needs-rereview` | New code landed after review; needs a fresh review |
+| 3 | `changes-requested` | Needs fixes, then re-review |
+| 4 | `approved` | Ready to merge if other gates are satisfied |
+| 5 | Draft | Still in progress |
 
 ### Step 2a: Check PR Code Authorship Against Agent Identity
 
@@ -117,12 +127,14 @@ ISSUES NEEDING PLANNING:
 
 Where `<reviewability>` is one of:
 - `approved + cross-model (last code: <identity>)` - reviewed and mergeable from a shiplog perspective
-- `request-changes + cross-model (last code: <identity>)` - reviewed, waiting on fixes
-- `no signed review + cross-model (last code: <identity>)` - you can perform the first gate-satisfying review
+- `changes-requested + cross-model (last code: <identity>)` - fixes are needed before another review
+- `needs-rereview + cross-model (last code: <identity>)` - prior review is stale; you can perform the next gate-satisfying review
+- `awaiting-review + cross-model (last code: <identity>)` - you can perform the first gate-satisfying review
 - `same-model (last code: <identity>)` - review blocked, same model
 - `unknown author` - no provenance or commit fallback available, treat as blocked
 
-If formal GitHub review badges disagree with signed **shiplog** comments, prefer the signed comment artifacts and note the mismatch briefly.
+If the PR body snapshot disagrees with signed **shiplog** review comments, prefer the newer signed comment artifact, note the mismatch briefly, and treat the snapshot as stale until it is refreshed.
+If formal GitHub review badges disagree with the snapshot or signed comments, prefer shiplog artifacts and note the mismatch briefly.
 
 ### Step 4: Recommend
 
@@ -152,13 +164,16 @@ Read tier tags from issue task lists (e.g., `[tier-1]`, `[tier-2]`, `[tier-3]`).
 #### Recommendation templates
 
 **When cross-model PRs need first review:**
-> Review PR #N - no signed review yet, cross-model, you can gate-satisfy review
+> Review PR #N - the PR body snapshot says awaiting review, and you can gate-satisfy the first review.
+
+**When a PR needs re-review after new code:**
+> Review PR #N - the PR body snapshot says needs re-review, so the earlier review is stale and you can provide the next gate-satisfying review.
 
 **When a PR already has signed approval:**
-> PR #N already has a signed cross-model approve comment. If the branch is mergeable and no newer code changed the authorship story, it is the top merge candidate.
+> PR #N already has an approved review snapshot. If the branch is mergeable and `Needs re-review since` is still `no`, it is the top merge candidate.
 
 **When all PRs are same-model or unknown:**
-> No open PR currently allows you to add a new gate-satisfying review. Same-model PRs need a different reviewer; unknown-author PRs need provenance clarified first. You can still implement ready issues.
+> No open PR currently allows you to add a new gate-satisfying review. Same-model PRs need a different reviewer; unknown-author PRs need provenance clarified first; legacy PRs without snapshots may need comment fallback before triage. You can still implement ready issues.
 
 **When issues are above your tier:**
 > Issue #N has tier-1 tasks - needs a reasoning model (e.g., Opus). Consider implementing tier-2/tier-3 issues instead.

--- a/skills/shiplog/pr.md
+++ b/skills/shiplog/pr.md
@@ -46,6 +46,7 @@ issue: <ISSUE_NUMBER>
 branch: issue/<ISSUE_NUMBER>-<slug>
 status: resolved
 updated_at: <ISO_TIMESTAMP>
+review_status: awaiting-review
 -->
 
 ## Summary
@@ -53,6 +54,15 @@ updated_at: <ISO_TIMESTAMP>
 [2-3 sentences: what this PR does and why]
 
 Closes #<ISSUE_NUMBER>
+
+## Review Status
+
+- **Current state:** awaiting review
+- **Last reviewed by:** none yet
+- **Last reviewed at:** n/a
+- **Reviewed commit:** n/a
+- **Source artifact:** none yet
+- **Needs re-review since:** no
 
 ## Journey Timeline
 
@@ -102,6 +112,7 @@ Authored-by: <family>/<version> (<tool>)
 ```
 
 The PR body is large enough that `--body-file` should be the preferred portable path.
+After every signed review comment and every post-review code push, refresh this review snapshot in place per `references/closure-and-review.md` and `references/signing.md`.
 
 ---
 
@@ -148,6 +159,7 @@ issue: <ISSUE_NUMBER>
 branch: issue/<ISSUE_NUMBER>-<slug>
 status: in-progress
 updated_at: <ISO_TIMESTAMP>
+review_status: awaiting-review
 -->
 
 ## Summary
@@ -155,6 +167,15 @@ updated_at: <ISO_TIMESTAMP>
 [2-3 sentences: what this PR ships and why it is a partial delivery]
 
 Addresses #<ISSUE_NUMBER> (completes T1, T2, T3)
+
+## Review Status
+
+- **Current state:** awaiting review
+- **Last reviewed by:** none yet
+- **Last reviewed at:** n/a
+- **Reviewed commit:** n/a
+- **Source artifact:** none yet
+- **Needs re-review since:** no
 
 ## Completed Tasks
 

--- a/skills/shiplog/references/artifact-envelopes.md
+++ b/skills/shiplog/references/artifact-envelopes.md
@@ -53,6 +53,12 @@ Place the envelope at the **top** of the artifact body (issue body, PR body, or 
 | `task_count` | no | integer | Total number of tasks in the issue body |
 | `tasks_complete` | no | integer | Number of checked tasks |
 | `max_tier` | no | string | Highest tier among remaining tasks: `tier-1`, `tier-2`, or `tier-3` |
+| `review_status` | no | string | PR review snapshot: `awaiting-review`, `changes-requested`, `approved`, or `needs-rereview` |
+| `last_reviewed_at` | no | ISO 8601 | Timestamp of the latest signed review reflected in the PR body snapshot |
+| `last_reviewed_by` | no | string | Reviewer identity for the latest signed review reflected in the PR body snapshot |
+| `reviewed_commit` | no | string | Commit SHA covered by the latest signed review reflected in the PR body snapshot |
+| `review_source` | no | string | Comment URL or artifact reference for the latest signed review reflected in the PR body snapshot |
+| `needs_rereview_since` | no | string | Commit SHA that made the prior review stale; omit when the snapshot is current |
 
 ### Triage fields
 
@@ -66,6 +72,17 @@ Use triage fields on issue-body `state` envelopes so agents can rank work withou
 | `in-progress` | Work has started |
 | `done` | All tasks are complete |
 
+### PR review snapshot fields
+
+Use review snapshot fields on PR-body `history` envelopes so agents can determine current review state without replaying the full PR comment thread.
+
+| Value | Meaning |
+|-------|---------|
+| `awaiting-review` | No signed review has been reflected in the PR body yet |
+| `changes-requested` | The latest signed review asked for fixes and no newer code has cleared that state |
+| `approved` | The latest signed review approved the reviewed commit and no newer code has made that review stale |
+| `needs-rereview` | New code landed after the latest signed review, so review must happen again before merge |
+
 ### Normalization rules
 
 - **Issue/PR numbers:** bare integers, no `#` prefix — e.g., `issue: 42` not `issue: #42`.
@@ -78,6 +95,10 @@ Use triage fields on issue-body `state` envelopes so agents can rank work withou
 - **Triage integers:** use bare integers, not quoted strings.
 - **`readiness`:** use only `ready`, `blocked`, `needs-design`, `in-progress`, or `done`.
 - **`max_tier`:** use `tier-1`, `tier-2`, or `tier-3`; omit it when all tasks are complete.
+- **`review_status`:** use only `awaiting-review`, `changes-requested`, `approved`, or `needs-rereview`.
+- **`last_reviewed_by`:** normalize like the signature body without the role prefix.
+- **`review_source`:** use the signed review comment URL when available.
+- **`needs_rereview_since`:** use the first commit SHA that invalidated the prior review; omit the field when the snapshot is current.
 - **Line endings:** normalize `\r\n` to `\n` before parsing envelopes on Windows.
 - **Unknown fields:** agents MUST ignore fields they do not recognize. This preserves forward compatibility as the schema evolves.
 
@@ -267,6 +288,19 @@ This reduces token cost on issues with long discussion threads.
 - **Verifier agents** should check for `verification` envelopes to find prior evidence before producing their own.
 - **Recovery flows** should check for `blocker` and `state` envelopes to understand where work was interrupted.
 
+### PR review retrieval
+
+For PR review triage, start with the PR body's latest-wins `history` artifact and its review snapshot fields:
+
+- `review_status`
+- `last_reviewed_by`
+- `last_reviewed_at`
+- `reviewed_commit`
+- `review_source`
+- `needs_rereview_since`
+
+If those fields are missing, stale, or contradicted by newer code or newer signed review artifacts, fall back to the signed `verification` comments on the PR thread.
+
 ---
 
 ## Examples
@@ -314,6 +348,7 @@ pr: 55
 branch: issue/42-auth-middleware
 status: resolved
 updated_at: 2026-03-14T18:00:00Z
+review_status: awaiting-review
 -->
 
 ## Summary
@@ -321,5 +356,14 @@ updated_at: 2026-03-14T18:00:00Z
 This PR adds JWT-based auth middleware.
 
 Closes #42
+
+## Review Status
+
+- **Current state:** awaiting review
+- **Last reviewed by:** none yet
+- **Last reviewed at:** n/a
+- **Reviewed commit:** n/a
+- **Source artifact:** none yet
+- **Needs re-review since:** no
 [Rest of PR timeline template...]
 ```

--- a/skills/shiplog/references/closure-and-review.md
+++ b/skills/shiplog/references/closure-and-review.md
@@ -193,6 +193,35 @@ Scope: <what was reviewed>
 
 See `references/signing.md` for the full signing protocol.
 
+### PR-body review snapshot
+
+Each shiplog PR body should also carry a latest-wins review snapshot on the PR's main `history` artifact. The signed review comment is the evidence trail. The PR body snapshot is the current summary used for low-token retrieval and triage.
+
+Minimum snapshot fields:
+
+- `Current state:` `awaiting review` | `changes requested` | `approved` | `needs re-review`
+- `Last reviewed by:`
+- `Last reviewed at:`
+- `Reviewed commit:`
+- `Source artifact:`
+- `Needs re-review since:`
+
+Mirror these values in the PR body's envelope fields when practical:
+
+- `review_status`
+- `last_reviewed_by`
+- `last_reviewed_at`
+- `reviewed_commit`
+- `review_source`
+- `needs_rereview_since`
+
+### Snapshot update rules
+
+1. **On PR creation:** initialize the snapshot as `awaiting review`.
+2. **After posting a signed review comment:** update the PR body snapshot in place to match that signed review artifact.
+3. **After code lands on the PR branch following a signed review:** mark the snapshot `needs re-review`, keep the last reviewed identity and source, and record the commit that made the prior review stale.
+4. **For legacy PRs without the snapshot:** fall back to signed review comments and backfill the snapshot on the next material PR-body edit when convenient.
+
 ### What constitutes "different model"
 
 - Different model family (e.g., Opus vs Sonnet, GPT-5 vs Claude).
@@ -204,6 +233,8 @@ See `references/signing.md` for the full signing protocol.
 
 When asked to review PRs, whether one PR or many (e.g., "review PRs", "check for PRs to review", "review PR #56"), the reviewing agent should:
 
+Read the PR body's review snapshot first. If the snapshot is missing, stale, or contradicted by newer code, fall back to the signed `Reviewed-by:` comment artifacts directly before deciding what still needs review.
+
 1. List open PRs on the repository.
 2. For each PR, inspect the newest signed shiplog author-side artifact you can verify for that work (for example the PR body `Authored-by:` or `Updated-by:` line, or a newer linked commit-note / handoff / amendment artifact) and any existing `Reviewed-by:` sign-offs.
 3. **Skip PRs where the newest verifiable author-side artifact or most recent review sign-off was authored by the same model and version.** Reviewing your own work adds no independent assurance — it is the anti-pattern this protocol exists to prevent.
@@ -213,6 +244,8 @@ When asked to review PRs, whether one PR or many (e.g., "review PRs", "check for
 6. Only proceed with self-authored PR review if the user explicitly confirms after the reminder. Mark such reviews as `self-review` per Section 4 audit trail rules.
 
 **Where to find review artifacts:** Shiplog review sign-offs are posted as issue/PR comments, not formal GitHub review events (see §4 GitHub API constraint). When checking for existing reviews, search the PR body plus issue/PR comments for `Reviewed-by:` and `Disposition:` lines. Do not rely on the formal reviews API endpoint alone — it will miss most AI-operated reviews.
+
+The PR body review snapshot is the latest-wins summary. Read it first for current state, then verify against signed review comments when the snapshot is missing, stale, or needs explanation.
 
 **What counts as "last touched":** The most recent signed shiplog artifact you can verify on either side: (a) the newest author-side `Authored-by:` or `Updated-by:` artifact associated with the work, or a newer amendment artifact, or (b) the most recent review `Reviewed-by:` sign-off. Do not treat raw Git commit metadata as model provenance; shiplog provenance lives in signed artifacts, not the commit object. If the branch moved after the last visible signed author artifact and the responsible model is unclear, treat authorship as unknown and do not claim a gate-satisfying same-model review.
 
@@ -297,6 +330,8 @@ Note: Self-review recorded as audit trail. This PR must not merge until an indep
 A PR review is not complete until the signed review artifact is posted on the PR as a GitHub comment. Local analysis that exists only in the agent's chat session does not satisfy the review protocol — the canonical artifact must be durable and visible on the PR timeline.
 
 **Default behavior:** After completing the review analysis and summarizing findings to the user, post the signed review artifact on the PR. Then link the posted comment in the user-facing response.
+
+**Snapshot follow-through:** After posting the signed review comment, refresh the PR body review snapshot in place so future retrieval flows can read current review state from the PR body first.
 
 **Explicit exceptions (require user opt-in):**
 - The user explicitly requested a dry run or local-only review.

--- a/skills/shiplog/references/pr-workflow.md
+++ b/skills/shiplog/references/pr-workflow.md
@@ -104,11 +104,12 @@ Use the shiplog PR timeline template from `../pr.md`. The PR body must include:
 1. Envelope metadata (`<!-- shiplog: ... -->`)
 2. Summary
 3. `Closes #N` or `Addresses #N (completes ...)`
-4. Journey Timeline (discoveries, decisions)
-5. Changes (commit list)
-6. Testing / Verification
-7. Knowledge for Future Reference
-8. Provenance signature (`Authored-by:`)
+4. Review Status snapshot
+5. Journey Timeline (discoveries, decisions)
+6. Changes (commit list)
+7. Testing / Verification
+8. Knowledge for Future Reference
+9. Provenance signature (`Authored-by:`)
 
 ### Labels
 
@@ -149,6 +150,8 @@ Every PR requires cross-model review before merge. After creating the PR:
 2. See `closure-and-review.md` for the full review protocol.
 3. The review must come from a different model than the one that authored the PR.
 4. Sign the review artifact per the agent identity signing rules.
+5. After each signed review comment, refresh the PR body's review snapshot in place.
+6. If new code lands after a review, flip the snapshot to `needs re-review` before asking for another review.
 
 Do not merge without a review sign-off unless the user explicitly overrides.
 

--- a/skills/shiplog/references/signing.md
+++ b/skills/shiplog/references/signing.md
@@ -44,6 +44,7 @@ If a shiplog artifact carries an incorrect or incomplete signature, correct it i
 - `Authored-by:` records the original author of an artifact body.
 - `Updated-by:` records a later model or human who materially edits that same artifact body. Preserve the original `Authored-by:` line and append a new `Updated-by:` line for each material edit, newest last.
 - `Reviewed-by:` is review-only. Do not use it for authorship or edit attribution.
+- Updating a PR body's review snapshot after publishing a signed review comment or after pushing code that makes a prior review stale counts as a material edit.
 - A **material edit** changes meaning, facts, scope, requirements, acceptance criteria, verification results, review disposition, or a handoff contract. Typos, formatting cleanups, and link-only fixes are cosmetic and do not need `Updated-by:`.
 
 ---
@@ -56,6 +57,15 @@ If a shiplog artifact carries an incorrect or incomplete signature, correct it i
 Use `supersedes` when the new artifact replaces the old one as canonical. Use `amends` when the new artifact corrects or clarifies but both should remain visible.
 
 If the platform does not expose reliable edit history, prefer an amendment artifact.
+
+### PR body review snapshot maintenance
+
+When a PR body carries the current review snapshot:
+
+- Post the signed `Reviewed-by:` comment first. That comment is the review evidence.
+- Then refresh the PR body snapshot in place so retrieval flows can read current review state without replaying the comment thread.
+- If new code lands after the latest signed review, update the snapshot to `needs-rereview` and record the commit that made the prior review stale.
+- Use the standard `Updated-by:` footer and envelope `updated_by` / `edit_kind` fields for these edits. Do not create a separate provenance role for review snapshots.
 
 ### In-Place Edit Footer
 


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 132
branch: issue/132-pr-body-review-snapshot
status: resolved
updated_at: 2026-03-19T23:15:00Z
review_status: approved
last_reviewed_by: claude/opus-4.6 (claude-code)
last_reviewed_at: 2026-03-19T23:15:00Z
reviewed_commit: 485e7da
review_source: https://github.com/devallibus/shiplog/pull/133#issuecomment-4093687293
-->

## Summary

Add a latest-wins PR-body review snapshot to the shiplog workflow so `hunt` and other retrieval flows can read current review state without replaying full PR comment threads. Signed `Reviewed-by:` comments remain the evidence trail and merge-gate artifact; the PR body becomes the cheap current-state summary.

Closes #132

## Review Status

- **Current state:** approved
- **Last reviewed by:** claude/opus-4.6 (claude-code)
- **Last reviewed at:** 2026-03-19T23:15:00Z
- **Reviewed commit:** 485e7da
- **Source artifact:** https://github.com/devallibus/shiplog/pull/133#issuecomment-4093687293
- **Needs re-review since:** no

## Journey Timeline

### Initial Plan
Issue #132 scoped the next step after the hunt audit: keep signed PR review comments as evidence, but materialize current review state on the PR body artifact so triage does not have to re-read comment threads every time.

### What We Discovered
- The current shiplog docs already distinguish evidence from summary in other places, so the review snapshot fits naturally as a latest-wins PR-body artifact rather than a second review channel.
- The live repo still has some encoding drift in older markdown files, so edits around those sections were safer when applied in smaller chunks.

### Implementation Issues
- Mixed encoding in older docs made some large patch contexts brittle; the fix was to edit the affected sections in smaller chunks and verify the resulting diff instead of force-rewriting the files wholesale.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Review source of truth | Keep signed review comments authoritative | They are the durable audit trail and existing merge-gate artifact |
| Current review summary | Store it on the PR body `history` artifact | `hunt` and retrieval flows already read the PR body first |
| Legacy rollout | Snapshot-first with signed-comment fallback | Existing open PRs should keep working during rollout without mandatory backfill |

### Changes Made

**Commits:**
- `485e7da` docs(#132): add PR-body review snapshot workflow

## Testing

- [x] Reviewed the diffs for `commands/shiplog/hunt.md`, `skills/shiplog/pr.md`, `skills/shiplog/references/artifact-envelopes.md`, `skills/shiplog/references/closure-and-review.md`, `skills/shiplog/references/pr-workflow.md`, and `skills/shiplog/references/signing.md`
- [x] `git diff --check`
- [x] Self-audit: implementation reviewed for redundancy, dead code, and simplification opportunities

**Verification summary:** Documentation-only change. Verification was diff review plus `git diff --check`; no automated tests were run.

## Stacked PRs / Related

- #125

## Knowledge for Future Reference

This change does not replace signed review comments. It makes the PR body the canonical current summary and leaves comment replay as the fallback path for legacy or stale PRs. If the repo later merges the `Last-code-by:` work from #125, the review snapshot remains compatible with that authorship fallback chain.

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
Updated-by: claude/opus-4.6 (claude-code)
Edit-kind: amendment
Edit-note: Refreshed PR body review snapshot after cross-model approve (comment 4093687293)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
