### PR TITLE
docs(#92): add orchestration protocol guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Use your best model for brainstorming, a fast one for implementation. **shiplog*
 
 When a reasoning model hands work to a faster model, the handoff is structured: allowed files, forbidden changes, stop conditions, verification requirements, and decision budget. If a tier-3 model reading the handoff would need to make a judgment call, the handoff is not specific enough.
 
+### Runtime-aware orchestration
+
+**shiplog** distinguishes orchestration from isolation. A task might stay inside one orchestrator with local parallel tool calls, fan out to bounded sub-agents, or move to an external session such as a tmux-backed background worker. The important part is that the dispatch contract and collection summary are durable, and that **shiplog** does not pretend a helper lane is an independent reviewer when it is not.
+
 ### Discovery protocol
 
 Find a bug while building a feature? **shiplog** classifies it and routes it:
@@ -158,7 +162,7 @@ Cross-platform from day one. Full Bash and PowerShell support using `gh ... --bo
 
 ### Worktree-first workflow
 
-One branch, one worktree, one agent. Safe concurrent operation by default — no branch-switching conflicts when multiple sessions are active.
+One branch, one worktree, one agent for the primary feature line. Parallel helpers may use sub-agents, forked workspaces, or external sessions, but **shiplog** still records the canonical feature branch/worktree and gives you a safe post-merge cleanup protocol.
 
 ---
 
@@ -259,7 +263,7 @@ For local iteration without reinstalling after every change.
 
 ## Slash Commands
 
-Invoke specific **shiplog** operations directly instead of loading the full skill:
+In environments that load repo command files, invoke specific **shiplog** operations directly instead of loading the full skill. Other runtimes may expose only the main skill and natural-language phase requests.
 
 | Command | What It Does |
 |---------|-------------|
@@ -276,7 +280,7 @@ Commands are lightweight entry points — each one gathers context and executes 
 
 ### Installing Commands
 
-Commands are installed automatically with the plugin. For manual installs, copy the commands directory:
+Command files are installed automatically with the Claude Code plugin. For manual installs in environments that support command directories, copy the commands directory:
 
 ```bash
 # Global (all projects)

--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -194,6 +194,23 @@ Roles: `Authored-by`, `Updated-by`, `Reviewed-by`, `Last-code-by`. See `referenc
 
 **Searching:** `Last-code-by:` → most recent code author on a PR branch. See `references/signing.md` for all searchable provenance fields.
 
+For orchestration flows, qualifiers may also record lane role, for example `orchestrator` or `sub-agent: reviewer`.
+
+---
+
+## Runtime-Aware Orchestration
+
+Shiplog records orchestration honestly instead of assuming one agent backend fits every runtime.
+
+- **Local parallel tool fan-out:** one orchestrator runs multiple independent helper calls in parallel. Good for sidecar reads; not a separate reviewer identity.
+- **Bounded sub-agent:** the orchestrator spawns a child lane with a scoped contract and collects a return artifact.
+- **External session delegation:** a separate tmux session, terminal agent, or other durable worker runs the lane outside the current orchestrator.
+- **Contract-only fallback:** shiplog emits the handoff or review contract when the current runtime cannot execute the lane itself.
+
+Isolation backend is tracked separately from the orchestration primitive. A git worktree, forked workspace, or tmux session may all isolate delegated work, but only the primary feature branch/worktree is shiplog's canonical branch record.
+
+See `references/orchestrator-protocol.md` for the capability mapping, fan-out templates, and cleanup protocol.
+
 ---
 
 ## Integration Map
@@ -214,6 +231,9 @@ This skill ORCHESTRATES. For activities that directly produce shiplog artifacts 
 | Fixing issues | `ork:fix-issue` | — | Timeline documentation of RCA |
 | Storing decisions | `ork:remember` | — | Structured `#ID: decision` entries |
 | Model routing | Built-in | — | Phase entry check (Step 0), routing prompts, handoffs |
+| Fan-out dispatch | `references/orchestrator-protocol.md` | runtime sub-agent/session tools | Dispatch artifact, per-lane contracts, collection summary |
+| Review and verifier lanes | `references/orchestrator-protocol.md` + `references/closure-and-review.md` | runtime reviewer/verifier tools | Auto-dispatch ladder and contract-only fallback |
+| Worktree hygiene | `references/orchestrator-protocol.md` | shell commands or external cleanup helpers | Workspace tracking and post-merge cleanup protocol |
 
 **Internalized workflows:** Commit and PR workflows are internalized in `references/` to enforce shiplog conventions (ID-first naming, provenance signing, envelope metadata, review gates). External skills may be used alongside for their non-convention features (validation agents, security scanning), but shiplog's conventions take precedence. See `LICENSES/` for attribution of the original skill sources.
 
@@ -231,6 +251,7 @@ This skill ORCHESTRATES. For activities that directly produce shiplog artifacts 
 - **Hotfix / emergency:** Fix first. Create issue and PR after, backfilling the timeline.
 - **Quiet mode — feature PR merges:** Close the `--log` PR. Knowledge is preserved in closed PR history.
 - **Quiet mode — feature branch rebased:** Rebase `--log` branch onto updated feature branch. Use `--force-with-lease`.
+- **Post-merge cleanup:** Remove a worktree only when its branch is merged, no open PR still depends on it, and it is not the active workspace. See `references/orchestrator-protocol.md`.
 
 ---
 

--- a/skills/shiplog/branch.md
+++ b/skills/shiplog/branch.md
@@ -6,13 +6,13 @@ description: "Phase 2: Create a branch from an issue, set up worktree, and post 
 # Branch Setup (Phase 2)
 
 <!-- routing: tier-2, plan then agent -->
-<!-- cross-cutting: references/model-routing.md (Step 0), references/signing.md, references/labels.md, references/shell-portability.md -->
+<!-- cross-cutting: references/model-routing.md (Step 0), references/signing.md, references/labels.md, references/shell-portability.md, references/orchestrator-protocol.md -->
 
 0. **Routing check.** Run the phase entry check from `references/model-routing.md`.
 
 1. **Load context.** `gh issue view <N> --json title,body,labels,comments,milestone` and search knowledge graph. If the issue is missing obvious Shiplog labels, backfill per `references/labels.md`.
 
-2. **Create branch (worktree-first).** One branch, one worktree, one agent.
+2. **Create branch (worktree-first).** One branch, one worktree, one agent for the primary line of work.
 
    Delegate to `superpowers:using-git-worktrees` if available. Otherwise:
    ```bash
@@ -30,9 +30,10 @@ description: "Phase 2: Create a branch from an issue, set up worktree, and post 
    Set-Location ../$branch
    ```
    See `references/shell-portability.md` for shell-specific notes.
+   If a delegated lane later uses a forked workspace, tmux session, or other runtime-specific isolation backend, keep this feature branch/worktree as the canonical shiplog record for the work.
    **Fallback (in-place checkout):** Only when the user explicitly requests no worktree.
 
-3. **Post timeline entry.** Full Mode: comment on the issue using the session-start template below. Quiet Mode: create `--log` branch + PR using the quiet-mode template below. Sign per `references/signing.md`.
+3. **Post timeline entry.** Full Mode: comment on the issue using the session-start template below. Quiet Mode: create `--log` branch + PR using the quiet-mode template below. Record the workspace path when known. Sign per `references/signing.md`.
 
 4. **Load plan** if it exists. Delegate to `superpowers:executing-plans` or `ork:implement`.
    For delegated or tier-3 work, the plan should define a contract: allowed files, forbidden changes, stop conditions, verification, return artifact, and decision budget.
@@ -58,6 +59,7 @@ updated_at: <ISO_TIMESTAMP>
 ## [shiplog/session-start] <Brief description of the work>
 
 **Branch:** `issue/<N>-<description>`
+**Workspace:** `[absolute-or-relative-worktree-path if known]`
 **Approach:** [1-2 sentences about the plan for this session]
 
 ---
@@ -117,6 +119,7 @@ updated_at: <ISO_TIMESTAMP>
 ## [shiplog/session-start] <Brief description of the work>
 
 **Branch:** `<branch>--log`
+**Workspace:** `[absolute-or-relative-worktree-path if known]`
 **Approach:** [1-2 sentences about the plan for this session]
 
 ---
@@ -204,6 +207,37 @@ updated_at: <ISO_TIMESTAMP>
 Authored-by: <family>/<version> (<tool>)
 ```
 
+For N-way orchestration, pair these per-lane contracts with the fan-out dispatch and collection artifacts from `references/orchestrator-protocol.md`.
+
+---
+
+## Worktree Lifecycle
+
+Track the primary feature worktree from session start through cleanup.
+
+- Record the workspace path in the session-start artifact when known.
+- Use `references/orchestrator-protocol.md` for fan-out dispatch when cleanup runs as its own lane.
+- After merge, remove only worktrees whose branches are merged and no longer back an open PR.
+
+Portable cleanup sequence:
+
+```bash
+git fetch origin
+git worktree list
+git branch --merged origin/$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+git worktree remove <path-to-worktree>
+git branch -d <branch-name>
+```
+
+```powershell
+git fetch origin
+$defaultBranch = gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+git worktree list
+git branch --merged origin/$defaultBranch
+git worktree remove <path-to-worktree>
+git branch -d <branch-name>
+```
+
 ---
 
 ## Edge Cases
@@ -211,3 +245,5 @@ Authored-by: <family>/<version> (<tool>)
 **Session resume:** Detect the issue from the current branch name or worktree. If the branch has an existing worktree, `cd` into it. Find linked PRs, read comments, add "Session resumed" timeline comment via `shiplog:timeline`.
 
 **Quiet mode — feature branch rebased:** Rebase `--log` branch onto updated feature branch. Use `--force-with-lease`.
+
+**Post-merge cleanup:** If the branch is merged and no open PR still depends on it, run the cleanup protocol above or dispatch a dedicated cleanup lane per `references/orchestrator-protocol.md`.

--- a/skills/shiplog/pr.md
+++ b/skills/shiplog/pr.md
@@ -6,7 +6,7 @@ description: "Phase 5: Create PR with timeline body, handle review gate, and lin
 # PR Timeline (Phase 5)
 
 <!-- routing: tier-1, plan -->
-<!-- cross-cutting: references/model-routing.md (Step 0), references/signing.md, references/closure-and-review.md, references/labels.md -->
+<!-- cross-cutting: references/model-routing.md (Step 0), references/signing.md, references/closure-and-review.md, references/labels.md, references/orchestrator-protocol.md -->
 
 0. **Routing check.** Run the phase entry check from `references/model-routing.md`.
 
@@ -16,11 +16,11 @@ description: "Phase 5: Create PR with timeline body, handle review gate, and lin
 
 3. **Quiet Mode.** Create a clean feature PR (no shiplog content). Add a final summary comment to the `--log` PR using the quiet-mode template below. Sign per `references/signing.md`.
 
-4. **Review gate.** Every PR requires cross-model review before merge. See `references/closure-and-review.md` for the review protocol, sign-off format, and merge authorization rules.
+4. **Review gate.** Every PR requires cross-model review before merge. Use the execution ladder in `references/closure-and-review.md`: bounded reviewer lane if available, then external session delegation, then a contract-only review handoff. Local parallel tool fan-out does not count as an independent reviewer identity.
 
 5. **Link and store.** PR body includes `Closes #<issue>` when the PR fully resolves the issue. For partial delivery, use `Addresses #<issue> (completes T1, T2, ...)` - see the partial-delivery template below and `references/closure-and-review.md` Section 1. Store key learning in knowledge graph.
 
-6. **Closure verification (optional).** When evidence-to-issue mapping is non-obvious, optionally delegate a bounded verifier agent per `references/closure-and-review.md`.
+6. **Closure verification (optional).** When evidence-to-issue mapping is non-obvious, optionally dispatch a verifier lane using the same orchestration ladder described in `references/closure-and-review.md` and `references/orchestrator-protocol.md`.
 
 ---
 
@@ -114,6 +114,8 @@ Last-code-by: <family>/<version> (<tool>)
 
 The PR body is large enough that `--body-file` should be the preferred portable path.
 After every signed review comment and every post-review code push, refresh this review snapshot in place per `references/closure-and-review.md` and `references/signing.md`.
+
+If review or cleanup work is dispatched in parallel, post the fan-out dispatch and collection artifacts from `references/orchestrator-protocol.md` instead of leaving that orchestration implicit in chat-only context.
 
 ---
 

--- a/skills/shiplog/references/closure-and-review.md
+++ b/skills/shiplog/references/closure-and-review.md
@@ -54,9 +54,9 @@ If the match between the issue and the evidence is ambiguous:
 1. **Do not close the issue.** Leave it open.
 2. Post a comment explaining the ambiguity.
 3. Tag the issue for human review or escalate to a higher-tier model.
-4. If a verifier agent is available, delegate the ambiguity check using the bounded handoff contract from `references/model-routing.md`.
+4. If a verifier lane is available, delegate the ambiguity check using the bounded handoff contract from `references/model-routing.md` and the dispatch/collection rules from `references/orchestrator-protocol.md`.
 
-### Optional verifier-agent workflow
+### Optional verifier-lane workflow
 
 Use this workflow when closure evidence is specific enough to audit but repetitive enough to delegate.
 The supervising model remains responsible for the closure decision.
@@ -64,6 +64,7 @@ The supervising model remains responsible for the closure decision.
 **Supervisor responsibilities:**
 - choose the candidate evidence links to inspect
 - assemble a bounded verifier contract using the handoff template from `references/model-routing.md`
+- choose the strongest available execution primitive from `references/orchestrator-protocol.md`
 - keep closure judgment for ambiguous issues, umbrella issues, and any case where the verifier reports mismatch or low confidence
 
 **Verifier may:**
@@ -294,18 +295,26 @@ All AI agents authenticate as the repository owner's GitHub account. Formal same
 - The cross-model provenance in the `Reviewed-by:` line is the authoritative review signal for shiplog, not the GitHub review badge.
 - Merge authorization follows the shiplog sign-off (see Section 5), not GitHub `reviewDecision`, review badges, or formal review states.
 
-### Best: Spawn a review agent
+### Best: Dispatch a bounded reviewer lane
 
-If the current tool supports spawning a bounded agent:
+If the current tool supports bounded sub-agents or an equivalent external-session lane:
 
 1. Prepare a review contract (see below).
-2. Spawn the reviewer with read-only access to the PR diff.
-3. The reviewer produces a signed review artifact.
-4. The author addresses findings or proceeds to merge on approval.
+2. Dispatch the reviewer using the strongest available primitive from `references/orchestrator-protocol.md`.
+3. Keep the reviewer read-only with respect to the review target unless the workflow explicitly allows reviewer-authored fixes.
+4. The reviewer produces a signed review artifact.
+5. The author addresses findings or proceeds to merge on approval.
+
+**Dispatch order:**
+
+1. **Bounded sub-agent** — best when the runtime can spawn a child reviewer with a scoped contract.
+2. **External session delegation** — use a tmux-backed session, separate terminal agent, or other durable session when that is the available isolation boundary.
+
+In both cases, post durable dispatch and collection artifacts when the review lane is material to the PR timeline. See `references/orchestrator-protocol.md`.
 
 ### Fallback: Generate a review contract
 
-If spawning is unavailable, generate a self-contained review contract for the user to hand to another model/tool:
+If no reviewer lane can be executed from the current runtime, generate a self-contained review contract for the user to hand to another model/tool:
 
 ```markdown
 ## Review Contract
@@ -334,6 +343,10 @@ Sign-off comment with:
 - Follow-ups: #<issue-number> or none
 - Any findings (tag non-blocking items with `[follow-up]`)
 ```
+
+### Not a valid substitute: local parallel tool fan-out
+
+Running multiple local helper calls in parallel can speed up evidence gathering, but it does **not** create an independent reviewer identity. Use local fan-out for sidecar reads or diff inspection helpers only. The signed review artifact must still come from a distinct reviewer lane or a separate model/tool.
 
 ### When independent review is unavailable: audit trail only
 
@@ -422,7 +435,7 @@ Before creating a PR, check:
 - Who will review? (Note in the PR body if pre-arranged.)
 
 After creating a PR:
-- If cross-model review is available, request it immediately.
+- If a reviewer lane is available, dispatch it immediately using the orchestration ladder above.
 - If not, generate the review contract and inform the user.
 
 ### Phase 4 (Commit-with-Context)

--- a/skills/shiplog/references/model-routing.md
+++ b/skills/shiplog/references/model-routing.md
@@ -208,6 +208,8 @@ When work transfers between models or tools — whether prompted by routing or n
 - Delegating bounded work to another agent
 - Any time the next model won't have the current conversation context
 
+For N-way dispatch, use this handoff as the per-lane contract and pair it with the fan-out dispatch and collection artifacts from `references/orchestrator-protocol.md`.
+
 ### Handoff template
 
 ```markdown

--- a/skills/shiplog/references/orchestrator-protocol.md
+++ b/skills/shiplog/references/orchestrator-protocol.md
@@ -1,0 +1,212 @@
+# Orchestrator Protocol Reference
+
+Shiplog orchestration is about bounded dispatch, durable collection, and honest capability claims. The orchestration primitive and the isolation backend are related but not interchangeable.
+
+---
+
+## 1. Core Rule
+
+When shiplog documents parallel or delegated work, it must answer two separate questions:
+
+1. **How is work dispatched?** Same agent, spawned sub-agent, external session, or contract-only handoff.
+2. **How is work isolated?** Git worktree, forked workspace, tmux session, or shared checkout.
+
+Do not collapse these into one label. A runtime may support bounded sub-agent dispatch with a forked workspace, while another team may use tmux sessions as the isolation backend for an external delegation lane. Shiplog records the dispatch contract and collection artifacts either way.
+
+---
+
+## 2. Orchestration Primitives
+
+Use the smallest primitive that accurately matches the runtime and the task.
+
+| Primitive | What it means | Safe for | Not for | Typical examples |
+|-----------|---------------|----------|---------|------------------|
+| **Local parallel tool fan-out** | One orchestrator runs multiple independent tool calls without creating a child agent identity | Read-only gathering, non-overlapping helper checks, parallel status queries | Independent review, code ownership claims, multi-step delegated implementation | Codex `multi_tool_use.parallel` |
+| **Bounded sub-agent** | The orchestrator spawns a child agent with a scoped contract and collects a return artifact | Review, verifier audits, bounded implementation slices, read-only exploration | Open-ended peer swarms, ambiguous ownership, silent long-running work | Codex `spawn_agent`; any runtime that exposes bounded worker agents |
+| **External session delegation** | Work is handed to a separate durable session or tool instance outside the current orchestrator | Long-running background work, tmux-backed agents, separate human-visible sessions, explicit worktree ownership | Implicit same-turn completion guarantees | tmux background sessions, separate terminal agents, dedicated worktree workers |
+| **Contract-only fallback** | Shiplog emits the contract but cannot execute the handoff itself in the current runtime | Review requests, verifier contracts, human handoff, later execution in another tool | Claiming parallelism or auto-spawn when none exists | Review contract, bounded handoff comment |
+
+**Selection rule:** Prefer local fan-out for fast sidecar reads, bounded sub-agents for auditable delegated work, external sessions for durable out-of-band work, and contract-only fallback when no execution primitive is available.
+
+---
+
+## 3. Isolation Backends
+
+Isolation is the boundary that keeps delegated work from trampling unrelated state.
+
+| Backend | What it isolates | Good fit | Caveat |
+|---------|------------------|----------|--------|
+| **Git worktree** | Branch + checkout + filesystem state | Primary feature work, long-lived branch ownership, explicit cleanup after merge | Requires lifecycle management and cleanup |
+| **Forked workspace** | Filesystem state inside the runtime's agent model | Bounded sub-agents that edit files without owning a git worktree | Not itself a shiplog worktree record |
+| **tmux session** | Terminal process state and session durability | Background agents, session handoff, file-marker or timeout-based completion | Session persistence is not branch ownership; track workspace separately |
+| **Shared checkout** | Little or none | Read-only helpers, very small local checks | Unsafe for concurrent branch switching or overlapping writes |
+
+**Shiplog default:** The primary feature branch remains worktree-first. Other isolation backends may be used for delegated lanes, but they do not replace the canonical branch/worktree record for the main line of work.
+
+---
+
+## 4. Capability Mapping
+
+Shiplog is capability-neutral. Document the actual primitive exposed by the runtime or companion tool instead of implying behavior.
+
+Examples:
+
+- **Codex `multi_tool_use.parallel`** -> local parallel tool fan-out
+- **Codex `spawn_agent`** -> bounded sub-agent with forked-workspace isolation
+- **tmux background session manager** -> external session delegation, typically paired with a shared JSON/file completion marker or timeout policy
+- **No agent runtime at all** -> contract-only fallback
+
+Do not claim:
+
+- that local parallel tool fan-out provides an independent reviewer identity
+- that forked workspace isolation is the same as shiplog's git worktree lifecycle
+- that tmux session delegation is automatically tracked unless shiplog artifacts record the dispatch and collection steps
+
+---
+
+## 5. Fan-Out Protocol
+
+Fan-out is a single orchestrator managing multiple bounded lanes in parallel.
+
+### Dispatch rules
+
+1. Decompose only independent lanes. If lane B blocks the very next local step, keep it local instead of dispatching it.
+2. Assign one owner per lane. The owner may be a sub-agent, external session, or the current orchestrator running local parallel tools.
+3. Give every delegated lane a bounded contract. Reuse the single-lane handoff template from `../branch.md` as the per-lane contract.
+4. Post a durable dispatch artifact when the fan-out affects project history, review state, or worktree/session lifecycle.
+5. Collect lanes explicitly. Do not let a successful lane silently imply the status of the others.
+
+### Dispatch announcement template
+
+Use one artifact for the overall fan-out instead of one top-level comment per lane. The per-lane contract can be embedded or linked.
+
+```markdown
+<!-- shiplog:
+kind: handoff
+issue: <ID>
+phase: <PHASE>
+updated_at: <ISO_TIMESTAMP>
+-->
+
+## [shiplog/worklog] #<ID>: fan-out dispatch
+
+**Orchestrator:** <family>/<version> (<tool>[, <qualifier>])
+**Primitive:** local-parallel-tools | bounded-sub-agents | external-sessions | mixed
+**Collection rule:** collect all lanes before merge / collect partial results after timeout / collect on next session
+
+### Lanes
+1. **reviewer**
+   - **Owner:** [sub-agent | external session | current orchestrator]
+   - **Goal:** [one concrete outcome]
+   - **Contract:** [link or heading reference]
+   - **Isolation:** worktree | forked workspace | tmux session | shared checkout
+2. **cleanup**
+   - **Owner:** [...]
+   - **Goal:** [...]
+   - **Contract:** [...]
+   - **Isolation:** [...]
+
+Authored-by: <family>/<version> (<tool>, orchestrator)
+```
+
+### Collection summary template
+
+```markdown
+<!-- shiplog:
+kind: state
+issue: <ID>
+phase: <PHASE>
+updated_at: <ISO_TIMESTAMP>
+-->
+
+## [shiplog/milestone] #<ID>: fan-out collection
+
+**Orchestrator:** <family>/<version> (<tool>[, <qualifier>])
+**Overall status:** complete | partial | blocked
+
+### Lane results
+- **reviewer:** completed | blocked | timed-out | superseded - [artifact link or reason]
+- **cleanup:** completed | blocked | timed-out | superseded - [artifact link or reason]
+
+### Remaining follow-up
+- [What still needs collection, re-dispatch, or user action]
+
+Authored-by: <family>/<version> (<tool>, orchestrator)
+```
+
+### Partial failure and late-return rules
+
+- If one lane blocks or times out, collect the successful lanes anyway and record the blocked lane explicitly.
+- If a late lane returns after the collection summary was posted, add an amendment or follow-up milestone artifact. Do not silently rewrite the prior summary.
+- External-session implementations may use JSON state files, file markers, or timeout heuristics internally. Shiplog only requires that the durable collection artifact records the outcome.
+
+---
+
+## 6. Auto-Dispatch Triggers
+
+### Review gate
+
+At PR time, use the strongest available primitive in this order:
+
+1. bounded sub-agent reviewer
+2. external session reviewer
+3. contract-only review handoff
+
+Local parallel tool fan-out does **not** satisfy independent review because it does not create a separate reviewer identity.
+
+### Closure verifier
+
+When closure evidence is repetitive and well-bounded, dispatch a verifier lane using the same ladder:
+
+1. bounded sub-agent verifier
+2. external session verifier
+3. contract-only verifier handoff
+
+The supervising actor still decides whether to close the issue.
+
+### Worktree hygiene
+
+After merge, or when resuming a repo with stale worktrees, run a cleanup lane if the check is independent of the critical path. Otherwise execute it locally.
+
+---
+
+## 7. Worktree Lifecycle
+
+Shiplog owns the record of the primary feature worktree even when helper lanes use other isolation backends.
+
+### Recording rule
+
+Session-start artifacts should record:
+
+- feature branch name
+- workspace path when known
+- isolation backend when non-default or important to the audit trail
+
+### Cleanup rule
+
+Only remove a worktree when all of the following are true:
+
+1. the branch has been merged to the default branch
+2. there is no open PR that still depends on that branch
+3. the worktree is not the active workspace for ongoing local changes
+
+### Cleanup commands
+
+```bash
+git fetch origin
+git branch --merged origin/$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+git worktree list
+git worktree remove <path-to-worktree>
+git branch -d <branch-name>
+```
+
+```powershell
+git fetch origin
+$defaultBranch = gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+git branch --merged origin/$defaultBranch
+git worktree list
+git worktree remove <path-to-worktree>
+git branch -d <branch-name>
+```
+
+If the runtime uses forked workspaces or tmux sessions, that runtime-specific cleanup is separate. Do not claim the git worktree is cleaned up unless the git worktree commands were actually run or the user explicitly confirmed equivalent cleanup.

--- a/skills/shiplog/references/phase-templates.md
+++ b/skills/shiplog/references/phase-templates.md
@@ -9,6 +9,7 @@ Template content now lives with the phase-specific sub-skills:
 - `../pr.md` for PR body templates and partial-delivery variants
 - `../timeline.md` for timeline, implementation-issue, milestone, blocker, and closure artifacts
 - `../lookup.md` for retrieval and triage-scan output formats
+- `orchestrator-protocol.md` for fan-out dispatch, collection summaries, and worktree cleanup
 - `closure-and-review.md` for review sign-off format, dispositions (approve, approve-with-follow-ups, request-changes, comment), and follow-up capture rules
 
 See `../SKILL.md` and the phase files above for the current canonical workflow.

--- a/skills/shiplog/references/signing.md
+++ b/skills/shiplog/references/signing.md
@@ -16,9 +16,24 @@ Every shiplog artifact (comments, PR bodies, review sign-offs) must carry a prov
 | `family` | Provider name, lowercase | `claude`, `openai`, `google` |
 | `version` | Model identifier | `opus-4.6`, `sonnet-4`, `gpt-5.4` |
 | `tool` | Runtime environment, lowercase | `claude-code`, `codex`, `cursor` |
-| `qualifier` | Optional tool-specific metadata | `effort: high`, `effort: medium` |
+| `qualifier` | Optional metadata string; may be compound when needed | `effort: high`, `orchestrator`, `sub-agent: reviewer`, `effort: high; orchestrator` |
 
 **Searching:** `Authored-by:` → original authorship. `Updated-by:` → later material editors. `Reviewed-by:` → review artifacts. `Last-code-by:` → most recent code author on a PR branch. `claude/` → all Claude artifacts. `(codex` → all Codex artifacts.
+
+### Orchestration role qualifiers
+
+When an artifact is emitted as part of a multi-lane flow, qualifiers may carry orchestration role information:
+
+- `orchestrator` — the current actor dispatched or collected delegated lanes
+- `sub-agent: reviewer` — delegated reviewer lane
+- `sub-agent: verifier` — delegated closure verifier lane
+- `sub-agent: implementation` — delegated implementation lane
+
+Examples:
+
+- `Authored-by: openai/gpt-5.4 (codex, effort: high; orchestrator)`
+- `Reviewed-by: claude/opus-4.6 (claude-code, sub-agent: reviewer)`
+- `Authored-by: openai/gpt-5.4 (codex, sub-agent: verifier)`
 
 ---
 

--- a/skills/shiplog/timeline.md
+++ b/skills/shiplog/timeline.md
@@ -6,7 +6,7 @@ description: "Phase 7: Add timeline comments for session starts, milestones, dis
 # Timeline Updates (Phase 7)
 
 <!-- routing: tier-3, agent -->
-<!-- cross-cutting: references/model-routing.md (Step 0), references/signing.md, references/labels.md -->
+<!-- cross-cutting: references/model-routing.md (Step 0), references/signing.md, references/labels.md, references/orchestrator-protocol.md -->
 
 0. **Routing check.** Run the phase entry check from `references/model-routing.md`.
 
@@ -127,7 +127,7 @@ See `references/closure-and-review.md` for the full closure and review protocol.
 
 ## Closure Verifier Handoff
 
-Use when a stronger model wants a bounded verifier agent to audit closure evidence:
+Use when a stronger model wants a bounded verifier lane to audit closure evidence:
 
 ```markdown
 ## [#<ID>] closure verifier handoff: <issue title>
@@ -154,6 +154,8 @@ Verify whether the listed evidence justifies closing issue #<ID>. Do not close t
 
 Authored-by: <family>/<version> (<tool>)
 ```
+
+If the verifier runs alongside other delegated work, pair this per-lane contract with the fan-out dispatch and collection artifacts from `references/orchestrator-protocol.md`.
 
 ## Closure Verification Note
 


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 92
branch: issue/92-orchestrator-protocol
status: resolved
updated_at: 2026-03-24T22:47:00Z
review_status: awaiting-review
-->

## Summary

This PR adds a canonical orchestration reference to **shiplog** and wires that model into the current split phase docs. The goal is to make parallel work, delegated review, verifier lanes, and worktree hygiene explicit without pretending every runtime has the same agent backend.

Closes #92

## Review Status

- **Current state:** awaiting review
- **Last reviewed by:** none yet
- **Last reviewed at:** n/a
- **Reviewed commit:** n/a
- **Source artifact:** none yet
- **Needs re-review since:** no

## Journey Timeline

### Initial Plan
Issue #92 started from a real workflow gap: **shiplog** described delegated review and multi-agent work, but the actual docs had no canonical fan-out protocol, no worktree cleanup guidance, and no clear distinction between orchestration primitives and isolation backends.

### What We Discovered
- The current `origin/master` layout has already split templates into phase-specific files, so the implementation needed to target `branch.md`, `pr.md`, `timeline.md`, and the reference docs rather than the older monolithic `phase-templates.md` plan.
- The most useful external feedback was not "switch everything to tmux" but "stop over-modeling capability tiers and separate the orchestration primitive from the isolation boundary."

### Implementation Issues
- The earlier local checkout was stale and 22 commits behind `origin/master`, so the work had to restart from a fresh worktree before any doc edits were trustworthy.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Orchestration model | Separate primitives from isolation backends | Keeps tmux, worktrees, forked workspaces, and contract-only fallbacks comparable without pretending they are the same thing |
| Review ladder | Bound reviewer lane -> external session -> contract-only fallback | Makes the docs truthful across runtimes and avoids vague "spawn a review agent" language |
| Worktree guidance | Keep the primary feature line worktree-first and document cleanup explicitly | Preserves existing shiplog safety rules while covering stale-worktree cleanup |

### Changes Made

**Commits:**
- `fb99237` docs(#92): add orchestration protocol guidance

## Testing

- [x] Manual diff review across README, SKILL, phase files, signing, and closure/review guidance
- [x] `git diff --check`
- [x] Documentation-only change; no automated tests exist in this repo for these docs paths

**Verification summary:** The new reference is linked from the active phase docs, the review ladder explicitly rejects local parallel tool fan-out as independent review, and the README no longer implies that command/runtime capabilities are identical across tools.

## Stacked PRs / Related

- #128
- #129

## Knowledge for Future Reference

This PR intentionally treats tmux as one external-session backend, not as **shiplog**'s new default runtime model. The durable part of the protocol is the signed dispatch contract, per-lane ownership, and collection summary; the backend can vary by tool.

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
Last-code-by: openai/gpt-5.4 (codex, effort: high)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*