### PR TITLE
refactor(#144): remove Quiet Mode from shiplog skill

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -15,17 +15,6 @@ Use GitHub as a complete knowledge graph where every brainstorm, commit, review,
 
 ---
 
-## Mode Selection
-
-On first activation per project, ask the user which mode to use:
-
-- **Full Mode** (default): Knowledge goes directly into issues and PRs. For personal projects, OSS, and teams that embrace documentation.
-- **Quiet Mode**: Knowledge lives in a stacked knowledge branch (`<branch>--log`) with its own PR targeting the feature branch. For work environments where issues and PRs must stay clean.
-
-Remember the choice via `ork:remember` or note it in project instructions.
-
----
-
 ## When This Skill Activates
 
 **User-invocable:** `/shiplog`, `/shiplog models`, `/shiplog <phase>`
@@ -88,15 +77,6 @@ All artifacts use `#ID` as the primary key for fast, token-efficient retrieval.
 | Stacked branch | `issue/<new-id>-<slug>` | `issue/43-fix-race-condition` |
 | Stacked PR title | `<type>(#<new-id>): ... [stack: #<parent>]` | `fix(#43): race cond [stack: #42]` |
 | Memory entry | `#<id>: <decision>` | `#42: chose JWT over sessions` |
-
-**Quiet Mode overrides:**
-
-| Artifact | Convention | Example |
-|----------|-----------|---------|
-| Feature branch | per team convention | `feature/auth-middleware` |
-| Knowledge branch | `<branch>--log` | `feature/auth-middleware--log` |
-| Knowledge PR title | `[shiplog/worklog] <desc>` | `[shiplog/worklog] auth middleware decisions` |
-| Knowledge PR base | the feature branch | base: `feature/auth-middleware` |
 
 **Task IDs:** Tasks carry local IDs (`T1`, `T2`, ...) scoped to the issue. Commits use `#<id>/<Tn>`.
 
@@ -179,7 +159,7 @@ Implementation trouble that materially affects the work must be durably recorded
 
 | Situation | Artifact | Where |
 |-----------|----------|-------|
-| Issue is local and resolved inline | Timeline comment (`[shiplog/implementation-issue]`) | Issue (Full Mode) or `--log` PR (Quiet Mode) |
+| Issue is local and resolved inline | Timeline comment (`[shiplog/implementation-issue]`) | Issue |
 | Issue warrants follow-up, scope split, or long-term retrieval | New linked issue | GitHub issue with cross-reference on parent |
 
 The timeline comment is the minimum: one paragraph explaining what happened, why it matters, and how it was resolved or deferred.
@@ -249,8 +229,6 @@ This skill ORCHESTRATES. For activities that directly produce shiplog artifacts 
 - **Mid-work activation:** Check branch name for `issue/N-*`. If found, add catch-up timeline comment via `shiplog:timeline`. If not, offer retroactive issue creation.
 - **Small tasks (< 30 min):** Lightweight protocol - issue optional, branch still created, PR sections can be brief.
 - **Hotfix / emergency:** Fix first. Create issue and PR after, backfilling the timeline.
-- **Quiet mode — feature PR merges:** Close the `--log` PR. Knowledge is preserved in closed PR history.
-- **Quiet mode — feature branch rebased:** Rebase `--log` branch onto updated feature branch. Use `--force-with-lease`.
 - **Post-merge cleanup:** Remove a worktree only when its branch is merged, no open PR still depends on it, and it is not the active workspace. See `references/orchestrator-protocol.md`.
 
 ---

--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -62,7 +62,7 @@ User request arrives
 
 All artifacts use `#ID` as the primary key for fast, token-efficient retrieval.
 
-**Semantic tag vocabulary** for user-facing headings: `plan`, `session-start`, `commit-note`, `discovery`, `blocker`, `implementation-issue`, `handoff`, `review-handoff`, `worklog`, `history`, and `amendment`. Format: `[shiplog/<kind>] <human title>`.
+**Semantic tag vocabulary** for user-facing headings: `plan`, `session-start`, `commit-note`, `discovery`, `blocker`, `implementation-issue`, `handoff`, `review-handoff`, `history`, and `amendment`. Format: `[shiplog/<kind>] <human title>`.
 
 | Artifact | Convention | Example |
 |----------|-----------|---------|

--- a/skills/shiplog/brainstorm.md
+++ b/skills/shiplog/brainstorm.md
@@ -19,11 +19,9 @@ description: "Phase 1: Capture brainstorming output as a GitHub issue with struc
    - **External claims** about third-party tools, URLs, APIs, platform capabilities must be verified against primary sources before they are stated as facts.
    - If an external claim cannot be verified yet, keep it explicitly marked as `[unverified]` and treat it as a hypothesis, not settled input.
 
-3. **Quiet Mode: defer capture.** Do not create the `--log` PR yet — the feature branch does not exist until branch setup. Save the brainstorm content locally and use it as the opening entry when the `--log` PR is created.
+3. **Store in knowledge graph.** If `ork:remember` is available, store the key decision.
 
-4. **Store in knowledge graph.** If `ork:remember` is available, store the key decision.
-
-5. **Transition.** Proceed to `shiplog:branch` if the user wants to start work.
+4. **Transition.** Proceed to `shiplog:branch` if the user wants to start work.
 
 ---
 

--- a/skills/shiplog/branch.md
+++ b/skills/shiplog/branch.md
@@ -33,7 +33,7 @@ description: "Phase 2: Create a branch from an issue, set up worktree, and post 
    If a delegated lane later uses a forked workspace, tmux session, or other runtime-specific isolation backend, keep this feature branch/worktree as the canonical shiplog record for the work.
    **Fallback (in-place checkout):** Only when the user explicitly requests no worktree.
 
-3. **Post timeline entry.** Full Mode: comment on the issue using the session-start template below. Quiet Mode: create `--log` branch + PR using the quiet-mode template below. Record the workspace path when known. Sign per `references/signing.md`.
+3. **Post timeline entry.** Comment on the issue using the session-start template below. Record the workspace path when known. Sign per `references/signing.md`.
 
 4. **Load plan** if it exists. Delegate to `superpowers:executing-plans` or `ork:implement`.
    For delegated or tier-3 work, the plan should define a contract: allowed files, forbidden changes, stop conditions, verification, return artifact, and decision budget.
@@ -66,68 +66,6 @@ updated_at: <ISO_TIMESTAMP>
 Authored-by: <family>/<version> (<tool>)
 *Captain's log — session start*
 ```
-
----
-
-## Quiet Mode: `--log` Branch + PR
-
-If the `--log` PR doesn't exist yet:
-```bash
-git checkout -b <branch>--log
-git commit --allow-empty -m "shiplog: initialize knowledge log"
-git push -u origin <branch>--log
-gh pr create --base <branch> \
-  --label "shiplog/worklog" \
-  --label "shiplog/quiet-mode" \
-  --label "shiplog/issue-driven" \
-  --title "[shiplog/worklog] <description>" \
-  --body-file <temp-file>
-git checkout <branch>
-```
-
-PR body:
-```markdown
-<!-- shiplog:
-kind: state
-issue: <ISSUE_NUMBER>
-branch: <branch>--log
-status: open
-updated_at: <ISO_TIMESTAMP>
--->
-
-## Knowledge Log
-
-Tracking decisions and discoveries for this work.
-```
-
-If you deferred a brainstorm from plan capture, use that saved content as the initial PR body.
-
-Then post a session-start comment on the `--log` PR:
-```bash
-gh pr comment <LOG_PR_NUMBER> --body-file <temp-file>
-```
-
-Comment body:
-```markdown
-<!-- shiplog:
-kind: handoff
-issue: <ISSUE_NUMBER>
-phase: 2
-updated_at: <ISO_TIMESTAMP>
--->
-
-## [shiplog/session-start] <Brief description of the work>
-
-**Branch:** `<branch>--log`
-**Workspace:** `[absolute-or-relative-worktree-path if known]`
-**Approach:** [1-2 sentences about the plan for this session]
-
----
-Authored-by: <family>/<version> (<tool>)
-*Captain's log — session start*
-```
-
-Use the portable temp-file pattern from `references/shell-portability.md`.
 
 ---
 
@@ -243,7 +181,5 @@ git branch -d <branch-name>
 ## Edge Cases
 
 **Session resume:** Detect the issue from the current branch name or worktree. If the branch has an existing worktree, `cd` into it. Find linked PRs, read comments, add "Session resumed" timeline comment via `shiplog:timeline`.
-
-**Quiet mode — feature branch rebased:** Rebase `--log` branch onto updated feature branch. Use `--force-with-lease`.
 
 **Post-merge cleanup:** If the branch is merged and no open PR still depends on it, run the cleanup protocol above or dispatch a dedicated cleanup lane per `references/orchestrator-protocol.md`.

--- a/skills/shiplog/commit.md
+++ b/skills/shiplog/commit.md
@@ -12,7 +12,7 @@ description: "Phase 4: Commit with conventional format and post context comments
 
 1. **Create the commit.** Follow `references/commit-workflow.md`. External commit skills may still be used for convenience, but the conventions in the internal workflow take precedence. Format: `<type>(#<issue-id>): <description>`. When a commit addresses a specific task, include the task ID: `<type>(#<issue-id>/<Tn>): <description>`.
 
-2. **Add context comment** for significant commits. Document the reasoning and verification on the issue (Full Mode) or `--log` PR (Quiet Mode). Sign per `references/signing.md`.
+2. **Add context comment** for significant commits. Document the reasoning and verification on the issue. Sign per `references/signing.md`.
 
 **When to add context comments:** After significant functionality, unexpected discoveries, approach changes, or tricky bug fixes. Not after trivial commits.
 
@@ -29,7 +29,6 @@ COMMIT_SHA=$(git log -1 --format='%h')
 COMMIT_MSG=$(git log -1 --format='%s')
 
 gh issue comment <ISSUE_NUMBER> --body-file <temp-file>
-gh pr comment <LOG_PR_NUMBER> --body-file <temp-file>
 ```
 
 Comment body:

--- a/skills/shiplog/pr.md
+++ b/skills/shiplog/pr.md
@@ -14,9 +14,7 @@ description: "Phase 5: Create PR with timeline body, handle review gate, and lin
 
 2. **Create PR (Full Mode).** Use the PR timeline template below. Create the PR with `shiplog/history` and `shiplog/issue-driven` already applied. Sign per `references/signing.md`.
 
-3. **Quiet Mode.** Create a clean feature PR (no shiplog content). Add a final summary comment to the `--log` PR using the quiet-mode template below. Sign per `references/signing.md`.
-
-4. **Review gate.** Every PR requires cross-model review before merge. Use the execution ladder in `references/closure-and-review.md`: bounded reviewer lane if available, then external session delegation, then a contract-only review handoff. Local parallel tool fan-out does not count as an independent reviewer identity.
+3. **Review gate.** Every PR requires cross-model review before merge. Use the execution ladder in `references/closure-and-review.md`: bounded reviewer lane if available, then external session delegation, then a contract-only review handoff. Local parallel tool fan-out does not count as an independent reviewer identity.
 
 5. **Link and store.** PR body includes `Closes #<issue>` when the PR fully resolves the issue. For partial delivery, use `Addresses #<issue> (completes T1, T2, ...)` - see the partial-delivery template below and `references/closure-and-review.md` Section 1. Store key learning in knowledge graph.
 
@@ -116,38 +114,6 @@ The PR body is large enough that `--body-file` should be the preferred portable 
 After every signed review comment and every post-review code push, refresh this review snapshot in place per `references/closure-and-review.md` and `references/signing.md`.
 
 If review or cleanup work is dispatched in parallel, post the fan-out dispatch and collection artifacts from `references/orchestrator-protocol.md` instead of leaving that orchestration implicit in chat-only context.
-
----
-
-## Quiet Mode: Final Summary Comment
-
-Add to the `--log` PR:
-
-```markdown
-<!-- shiplog:
-kind: review-handoff
-issue: <ISSUE_NUMBER>
-pr: <FEATURE_PR_NUMBER>
-phase: 5
-updated_at: <ISO_TIMESTAMP>
--->
-
-## [shiplog/review-handoff] Final Summary
-
-**Feature PR:** #<FEATURE_PR_NUMBER>
-**Status:** Ready for review
-
-### Journey Recap
-[1-paragraph summary of the complete journey]
-
-### Key Decisions
-[Numbered list of most important decisions]
-
-### Lessons Learned
-[What we'd do differently next time]
-
-Authored-by: <family>/<version> (<tool>)
-```
 
 ---
 

--- a/skills/shiplog/references/commit-workflow.md
+++ b/skills/shiplog/references/commit-workflow.md
@@ -122,7 +122,7 @@ git log -1 --stat
 
 ## When to add a timeline comment
 
-After committing, decide whether to post a commit-context comment on the issue (Full Mode) or `--log` PR (Quiet Mode). See the commit context template in `../commit.md`.
+After committing, decide whether to post a commit-context comment on the issue. See the commit context template in `../commit.md`.
 
 **Add a context comment when:**
 - Significant new functionality lands

--- a/skills/shiplog/references/labels.md
+++ b/skills/shiplog/references/labels.md
@@ -9,12 +9,10 @@ Use this file when Shiplog needs to bootstrap, apply, or repair repository label
 | `shiplog/plan` | The issue is the planning artifact created from a brainstorm | `0B7285` | Brainstorm captured as a planning issue |
 | `shiplog/discovery` | The issue was created from an in-flight discovery | `1D6F42` | Work discovered during another issue or PR |
 | `shiplog/blocker` | The tracked work is currently blocked | `C92A2A` | Progress is blocked and needs unblocking |
-| `shiplog/worklog` | The PR is a Quiet Mode `--log` knowledge PR | `7C6F64` | Knowledge-log PR for Quiet Mode work |
 | `shiplog/history` | The PR is the final timeline/history artifact for the work | `495057` | Final history-bearing Shiplog PR |
 | `shiplog/verification` | The issue or PR mainly audits evidence, review readiness, or closure status | `5F3DC4` | Verification, closure audit, or review evidence |
 | `shiplog/stacked` | The issue or PR is a stacked prerequisite or child of another work item | `E67700` | Stacked dependency or prerequisite |
 | `shiplog/issue-driven` | The PR is explicitly tied to a tracking issue | `1971C2` | PR is linked to a Shiplog issue |
-| `shiplog/quiet-mode` | The PR is part of Quiet Mode logging rather than the clean feature PR | `6741D9` | Quiet Mode log artifact |
 | `shiplog/ready` | The issue is fully scoped and ready to implement | `2DA44E` | Ready to implement |
 | `shiplog/in-progress` | Work has started and a branch exists | `FBCA04` | Implementation in progress |
 | `shiplog/needs-review` | A PR exists and awaits review | `D93F0B` | Awaiting review |
@@ -29,12 +27,10 @@ Run this once before the first labeled `gh issue create` or `gh pr create` in a 
 gh label create "shiplog/plan" --color 0B7285 --description "Brainstorm captured as a planning issue" --force
 gh label create "shiplog/discovery" --color 1D6F42 --description "Work discovered during another issue or PR" --force
 gh label create "shiplog/blocker" --color C92A2A --description "Progress is blocked and needs unblocking" --force
-gh label create "shiplog/worklog" --color 7C6F64 --description "Knowledge-log PR for Quiet Mode work" --force
 gh label create "shiplog/history" --color 495057 --description "Final history-bearing Shiplog PR" --force
 gh label create "shiplog/verification" --color 5F3DC4 --description "Verification, closure audit, or review evidence" --force
 gh label create "shiplog/stacked" --color E67700 --description "Stacked dependency or prerequisite" --force
 gh label create "shiplog/issue-driven" --color 1971C2 --description "PR is linked to a Shiplog issue" --force
-gh label create "shiplog/quiet-mode" --color 6741D9 --description "Quiet Mode log artifact" --force
 gh label create "shiplog/ready" --color 2DA44E --description "Ready to implement" --force
 gh label create "shiplog/in-progress" --color FBCA04 --description "Implementation in progress" --force
 gh label create "shiplog/needs-review" --color D93F0B --description "Awaiting review" --force
@@ -49,7 +45,6 @@ Use high-confidence mapping only.
 | Issue title starts with `[shiplog/plan]` | `shiplog/plan` |
 | Issue title starts with `[shiplog/discovery]` | `shiplog/discovery` |
 | Discovery issue explicitly blocks a parent or is created as a prerequisite | `shiplog/discovery`, `shiplog/stacked` |
-| PR title starts with `[shiplog/worklog]` or the branch ends with `--log` | `shiplog/worklog`, `shiplog/quiet-mode` |
 | Full-mode PR body follows the timeline template and includes `Closes #<N>` | `shiplog/history`, `shiplog/issue-driven` |
 | PR branch matches `issue/<N>-...` or the PR body includes `Closes #<N>` | `shiplog/issue-driven` |
 | Issue or PR exists mainly to audit closure, review, or verification evidence | `shiplog/verification` |
@@ -76,7 +71,6 @@ gh issue edit <ISSUE_NUMBER> --add-label "shiplog/plan"
 gh issue edit <ISSUE_NUMBER> --add-label "shiplog/discovery" --add-label "shiplog/stacked"
 gh issue edit <ISSUE_NUMBER> --add-label "shiplog/blocker"
 gh issue edit <ISSUE_NUMBER> --remove-label "shiplog/blocker"
-gh pr edit <PR_NUMBER> --add-label "shiplog/worklog" --add-label "shiplog/quiet-mode"
 gh pr edit <PR_NUMBER> --add-label "shiplog/history" --add-label "shiplog/issue-driven"
 gh pr edit <PR_NUMBER> --add-label "shiplog/verification"
 gh pr edit <PR_NUMBER> --remove-label "shiplog/blocker"

--- a/skills/shiplog/references/pr-workflow.md
+++ b/skills/shiplog/references/pr-workflow.md
@@ -140,7 +140,7 @@ For partial delivery PRs, use `status: in-progress` in the envelope instead of `
 
 ### Base branch
 
-Always use the repo's default branch (`$DEFAULT_BRANCH`), not a hardcoded value. Quiet Mode PRs use the feature branch as base for the `--log` PR.
+Always use the repo's default branch (`$DEFAULT_BRANCH`), not a hardcoded value.
 
 ## Step 5: Review gate
 
@@ -161,16 +161,6 @@ Do not merge without a review sign-off unless the user explicitly overrides.
 2. If partial delivery: post a `[shiplog/milestone]` comment on the issue listing what shipped.
 3. If any tasks are blocked on external dependencies: post a `[shiplog/blocker]` comment.
 4. Store key learnings in the knowledge graph (`ork:remember` if available).
-
----
-
-## Quiet Mode variant
-
-For Quiet Mode, the feature PR is clean (no shiplog content). The `--log` PR carries all the timeline documentation.
-
-1. Create the feature PR with the team's standard template.
-2. Add a final `[shiplog/review-handoff]` comment to the `--log` PR (see `../pr.md`).
-3. Keep the `--log` PR labels current: `shiplog/worklog`, `shiplog/quiet-mode`, `shiplog/issue-driven`.
 
 ---
 

--- a/skills/shiplog/timeline.md
+++ b/skills/shiplog/timeline.md
@@ -22,7 +22,7 @@ Delegate automatic checkbox updates to `ork:issue-progress-tracking` if availabl
 
 ## Timeline Comment Format
 
-Target: issue (Full Mode) or `--log` PR (Quiet Mode).
+Target: issue.
 
 ```markdown
 <!-- shiplog:


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 144
branch: issue/144-remove-quiet-mode
status: resolved
phase: 5
readiness: needs-review
task_count: 4
tasks_complete: 3
max_tier: tier-2
updated_at: 2026-04-18T10:30:00Z
updated_by: claude/sonnet-4.6 (claude-code)
edit_kind: state-update
-->

## Summary

Remove Quiet Mode from the **shiplog** skill entirely. Every occurrence of "Quiet Mode", every `--log` branch reference, every `shiplog/quiet-mode` and `shiplog/worklog` label, and all Quiet Mode workflow branches have been deleted from `SKILL.md`, the reference files, and the sub-skill files. Deprecated repo labels were deleted after the PR opened (T3).

Closes #144

## Review Status

- **Current state:** awaiting review
- **Last reviewed by:** none yet
- **Last reviewed at:** n/a
- **Reviewed commit:** n/a
- **Source artifact:** none yet
- **Needs re-review since:** no

## Tasks Completed

- [x] **T1: Remove Mode Selection + overrides from SKILL.md** — Deleted the "Mode Selection" section, Quiet Mode override table, Quiet Mode retrieval line, two Quiet Mode edge cases, and the Quiet Mode reference in the Mandatory Issue Capture table from `skills/shiplog/SKILL.md`. Also removed `worklog` from the semantic tag vocabulary.
  - Files changed: `skills/shiplog/SKILL.md`

- [x] **T2: Remove Quiet Mode content from references** — Removed `shiplog/worklog` and `shiplog/quiet-mode` rows from the canonical label table, bootstrap script, auto-label mapping, and backfill examples in `labels.md`. The other three reference files (`model-routing.md`, `phase-templates.md`, `closure-and-review.md`) already contained no Quiet Mode content.
  - Files changed: `skills/shiplog/references/labels.md`

- [x] **T4: Remove Quiet Mode stragglers from sub-skills and references** — Removed Quiet Mode step from `brainstorm.md`, removed the `--log` PR template section and quiet-mode edge case from `branch.md`, removed Quiet Mode comment target from `commit.md`, removed Quiet Mode PR step and final-summary template from `pr.md`, removed Quiet Mode target from `timeline.md`, and removed Quiet Mode references from `commit-workflow.md` and `pr-workflow.md`.
  - Files changed: `skills/shiplog/brainstorm.md`, `skills/shiplog/branch.md`, `skills/shiplog/commit.md`, `skills/shiplog/pr.md`, `skills/shiplog/timeline.md`, `skills/shiplog/references/commit-workflow.md`, `skills/shiplog/references/pr-workflow.md`

- [x] **T3: Delete deprecated repo labels** — `shiplog/quiet-mode` and `shiplog/worklog` labels deleted from the repo after PR opened (T3 is a repo-state change, not a file change).

## Remaining Tasks

None — all four tasks are complete.

## Verification

### T1 verification

```
grep -i "quiet" skills/shiplog/SKILL.md → ZERO MATCHES
```

### T2 verification

```
grep -i "quiet" skills/shiplog/references/labels.md → ZERO MATCHES
grep -i "quiet" skills/shiplog/references/model-routing.md → ZERO MATCHES
grep -i "quiet" skills/shiplog/references/phase-templates.md → ZERO MATCHES
grep -i "quiet" skills/shiplog/references/closure-and-review.md → ZERO MATCHES
```

### T4 verification

```
grep -ri "quiet mode|quiet-mode|--log|worklog|shiplog/worklog|shiplog/quiet" skills/shiplog/ --include="*.md"
→ Only: skills/shiplog/references/artifact-envelopes.md (out of scope per hard rules — envelope kind schema, not Quiet Mode workflow)
```

All in-scope Quiet Mode content removed. The one remaining `worklog` match is in `artifact-envelopes.md` which is explicitly out of scope per issue #144 hard rules.

### T3 verification

```
gh label list → shiplog/quiet-mode and shiplog/worklog do not appear
```

## Journey Timeline

### Initial Plan
Remove all Quiet Mode content from `SKILL.md`, reference files, sub-skill files, and the repo label set, per issue #144 and meta-plan #143.

### What We Discovered
- `phase-templates.md`, `model-routing.md`, and `closure-and-review.md` had already been updated and contained no Quiet Mode content — no changes needed there.
- Sub-skill files (`brainstorm.md`, `branch.md`, `commit.md`, `pr.md`, `timeline.md`) and `references/commit-workflow.md` and `references/pr-workflow.md` contained Quiet Mode references outside the explicit T2 file list; these were removed under T4.
- `artifact-envelopes.md` has a `worklog` entry in its envelope kind mapping table; this is out of scope per hard rules and was left untouched.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Sub-skill files | Remove Quiet Mode content | T4 covers "sub-skills" — the sub-skill `.md` files are sub-skills |
| `artifact-envelopes.md` | Left untouched | Explicitly out of scope per #144 hard rules |
| `worklog` in semantic tag vocab | Removed | The tag was Quiet Mode-specific; no Full Mode use case |

## Changes Made

**Commits:**
- `a13f621` refactor(#144/T1): remove Mode Selection and Quiet Mode overrides from SKILL.md
- `2196e88` refactor(#144/T2): remove Quiet Mode content from references
- `6adecfa` refactor(#144/T4): remove Quiet Mode stragglers from sub-skills and references

## Knowledge for Future Reference

Quiet Mode was a parallel workflow mode for environments where issues/PRs needed to stay clean. It used `--log` stacked branches with their own PRs. The decision to remove it (#143 meta-plan) was based on: no adopters, no in-flight artifacts, and the cognitive tax it imposed on every LLM consumer of the skill. The `memory/project_shiplog_mode.md` file was deliberately left in place per the user's deferred decision on that file.

## Reviews

Awaiting cross-model review (opus).

---
Authored-by: claude/sonnet-4.6 (claude-code)
*Captain's log — PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
