### PR TITLE
refactor(#150): remove invented tags (session-end, approach-change) from canonical map

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -213,14 +213,14 @@ Each `/shiplog <phase>` slash command maps to one sub-skill file. Load the file 
 
 | `kind:` (envelope) | Title tag `[shiplog/<tag>]` | GitHub label `shiplog/<label>` | Description |
 |--------------------|-----------------------------|-------------------------------|-------------|
-| `state` | `plan`, `session-start`, `session-resume`, `milestone`, `discovery`, `implementation-issue`, `approach-change` | `plan` (planning issues) | Current status snapshot of an issue or PR |
+| `state` | `plan`, `session-start`, `session-resume`, `milestone`, `discovery`, `implementation-issue` | `plan` (planning issues) | Current status snapshot of an issue or PR |
 | `handoff` | `session-start`, `review-handoff` | — | Context transfer between tiers, tools, or sessions |
 | `verification` | `commit-note`, `review-handoff`, `verification` | `verification` | Evidence of testing, review, or quality check |
 | `commit-note` | `commit-note` | — | Reasoning behind a specific commit |
 | `review-handoff` | `review-handoff` | — | Review request or review completion artifact |
 | `amendment` | `amendment` | — | Correction or clarification for an existing signed artifact |
 | `blocker` | `blocker` | `blocker` | Something preventing progress |
-| `history` | `history`, `session-end` | `history` | Retrospective summary for knowledge retrieval |
+| `history` | `history` | `history` | Retrospective summary for knowledge retrieval |
 
 **Lifecycle labels** (`shiplog/ready`, `shiplog/in-progress`, `shiplog/needs-review`) are not tied to an artifact `kind:`. They track issue/PR workflow state and are mutually exclusive. Apply them per the Triage Field Maintenance table below.
 
@@ -234,7 +234,7 @@ For the full label set, color codes, and bootstrap CLI snippets, see `references
 
 All artifacts use `#ID` as the primary key for fast, token-efficient retrieval.
 
-**Semantic tag vocabulary** for user-facing headings: `plan`, `session-start`, `session-resume`, `commit-note`, `discovery`, `blocker`, `implementation-issue`, `handoff`, `review-handoff`, `history`, `amendment`, `milestone`, `approach-change`, `session-end`, and `verification`. Format: `[shiplog/<tag>] <human title>`. See the Canonical Kind → Tag → Label Map section for the authoritative mapping.
+**Semantic tag vocabulary** for user-facing headings: `plan`, `session-start`, `session-resume`, `commit-note`, `discovery`, `blocker`, `implementation-issue`, `handoff`, `review-handoff`, `history`, `amendment`, `milestone`, and `verification`. Format: `[shiplog/<tag>] <human title>`. See the Canonical Kind → Tag → Label Map section for the authoritative mapping.
 
 | Artifact | Convention | Example |
 |----------|-----------|---------|

--- a/skills/shiplog/references/artifact-envelopes.md
+++ b/skills/shiplog/references/artifact-envelopes.md
@@ -170,7 +170,7 @@ updated_at: 2026-03-14T14:30:00Z
 
 **`blocker`** — Write when something blocks progress. Supersedes the previous blocker if the blocking condition changes. Include `status: blocked`.
 
-**`history`** — Write when summarizing a completed journey (e.g., PR body timeline, session-end recap). Useful for future retrieval queries.
+**`history`** — Write when summarizing a completed journey (e.g., PR body timeline, retrospective recap). Useful for future retrieval queries.
 
 ### Relationship to semantic tags
 
@@ -185,7 +185,7 @@ Envelope `kind` is the machine key. The `[shiplog/<tag>]` heading is the human k
 | `review-handoff` | `review-handoff` |
 | `amendment` | `amendment` |
 | `blocker` | `blocker` |
-| `history` | `history`, `session-end` |
+| `history` | `history` |
 
 One comment may carry a human tag and a different envelope kind when the machine purpose differs from the human-facing label. The envelope is authoritative for retrieval; the tag is authoritative for human scanning.
 

--- a/skills/shiplog/timeline.md
+++ b/skills/shiplog/timeline.md
@@ -12,7 +12,7 @@ description: "Phase 7: Add timeline comments for session starts, milestones, dis
 
 1. **Add timeline comments** when: starting a new session, changing approach, finding something unexpected, completing a milestone, or getting blocked. Sign per the signing spec — see SKILL.md §8 (Agent Identity Signing).
 
-2. **Use the standard format** below. Comment types: `session-start`, `session-resume`, `milestone`, `discovery`, `implementation-issue`, `approach-change`, `blocker`, `session-end`.
+2. **Use the standard format** below. Comment types: `session-start`, `session-resume`, `milestone`, `discovery`, `implementation-issue`, `blocker`.
 
 3. **Keep state labels honest.** Add `shiplog/blocker` when work cannot proceed. Remove it when the blocker clears.
 
@@ -61,9 +61,7 @@ Authored-by: <family>/<version> (<tool>)
 | `milestone` | `state` |
 | `discovery` | `state` |
 | `implementation-issue` | `state` |
-| `approach-change` | `state` |
 | `blocker` | `blocker` |
-| `session-end` | `history` |
 
 Use `kind: blocker` only when the discovery actually prevents progress. Informational discoveries stay `state` artifacts, while blocking discoveries should use the explicit `blocker` tag or the blocker-specific template.
 


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 150
pr: 153
phase: 5
review_status: approved-with-notes
readiness: done
updated_at: 2026-04-18T14:05:00Z
-->

## Summary

- Removes invented tags `session-end` and `approach-change` from the canonical **shiplog** vocabulary and from the kind→tag maps that reference them.
- Collapses the `history` kind→tag row to a single-tag mapping in both SKILL.md and `references/artifact-envelopes.md`, which is the cleanest resolution after Quiet Mode removal eliminated `worklog`.
- Scope expanded mid-work to include `skills/shiplog/timeline.md` after grep showed the tags lived there too — see the `[shiplog/implementation-issue]` comment on #150.

Closes #150.

## Journey Timeline

### Initial Plan

Per #150: mechanical tier-1 cleanup removing `session-end` and `approach-change` from SKILL.md's vocabulary sentence and kind map, and collapsing the `history` row in `references/artifact-envelopes.md`. Expected two small edits across two files.

### What We Discovered

**Scope surprise: `skills/shiplog/timeline.md` also carries both tags on master.** The issue body asserted "zero matches on a repo-wide grep of master," but `git grep` on the implementation branch surfaced three additional hits — line 15 (comment-types enumeration) and lines 64/66 (kind→tag table rows). These were introduced alongside the SKILL.md changes in the #145 workstream and missed during triage.

**Rationale for in-scope handling, not a follow-up issue.** Splitting the timeline.md cleanup into a separate PR would have left the repository in an internally inconsistent state between merges: the canonical map in SKILL.md would forbid tags that the `timeline.md` sub-skill still actively instructs writers to use. A new linked issue is the right tool when a discovery introduces new design work; here the work is the same tier-1 mechanical removal and belongs in the same atomic change. The expansion was captured in the `[shiplog/implementation-issue]` timeline comment on #150 and reflected by an amendment to the issue body (task count 2 → 3).

**In-flight branches already carry the master state.** `origin/issue/146-colocate-subskills` and `origin/issue/147-restructure-skill-md` both contain the same three files with identical lines — they will pick up this cleanup on the next rebase onto master, so no cross-branch coordination is required before merging here.

### Key Decisions Made

| Decision | Why | Alternative considered |
|---|---|---|
| Collapse `history` kind → single tag `history` | Post-Quiet-Mode, there is no remaining artifact flow that the second tag names. Single-tag mapping matches the sub-skill copy. | Keep dual mapping pointing at a new tag — rejected, would just re-invent vocabulary. |
| Expand scope to `timeline.md` instead of new follow-up issue | Tier-1 mechanical edit, identical rationale to T1/T2; splitting would leave map inconsistent between merges. | Defer to follow-up — rejected per shiplog "implementation-issue" rubric (inline-resolvable). |
| Rewrite `history` description prose in `artifact-envelopes.md` to "retrospective recap" instead of "session-end recap" | Leaving the invented tag in sub-skill prose would re-leak the vocabulary the map no longer permits. | Leave prose untouched — rejected, would contradict the canonical map. |
| Leave `timeline.md` line 3 / line 13 scenario prose ("approach changes", "changing approach") alone | Those phrases describe user scenarios, not tag names. Scenarios remain valid; the resulting comments just tag as `discovery` or `amendment`. Restructuring the trigger narrative is out of scope for a tier-1 vocabulary cleanup. | Rewrite motivating prose — rejected, exceeds mechanical-cleanup charter. |

### Changes Made

- `691730b refactor(#150/T1): remove invented tags from SKILL.md kind map + vocab` — edits the Canonical Kind → Tag → Label Map (`state`, `history` rows) and the semantic vocabulary sentence in `skills/shiplog/SKILL.md`.
- `a0ec51d refactor(#150/T2): collapse history kind→tag row + drop session-end prose` — collapses the `history` row and updates the kind description prose in `skills/shiplog/references/artifact-envelopes.md`.
- `1264807 refactor(#150/T3): drop invented tags from timeline sub-skill` — removes the tags from the comment-types enumeration and the two corresponding Tag-to-Kind Mapping rows in `skills/shiplog/timeline.md`.

## Testing

- [x] `git grep "session-end\|approach-change"` on the branch returns zero matches across the full repository.
- [x] `git grep` on each touched file individually (`SKILL.md`, `artifact-envelopes.md`, `timeline.md`) returns zero matches.
- [x] Visual diff review confirms no unrelated edits (table whitespace, prose adjacent to edits, frontmatter).
- [x] Canonical Kind → Tag → Label Map in SKILL.md is still syntactically a well-formed markdown table.
- [x] Kind→tag maps in SKILL.md and `artifact-envelopes.md` are consistent with each other for the `state` and `history` rows.
- [ ] Cross-model review (required by shiplog review gate before merge).

## Knowledge for Future Reference

- **Scope claims in issue bodies need a grep-verify step at branch creation.** The "zero matches repo-wide" claim on #150 was written from context memory, not from a live grep, and missed a file. Treat such assertions as hypotheses to re-verify, not as facts — especially for mechanical cleanup issues where the scope is defined by grep output.
- **Vocabulary lives in at least three surfaces.** SKILL.md (canonical map + vocab sentence), `references/artifact-envelopes.md` (schema + tag mirror table), and `skills/shiplog/timeline.md` (writer-facing enumeration + tag-to-kind table). Adding or removing a tag without touching all three leaves the skill self-contradictory.
- **`worklog` removal left a dual-mapping shaped hole.** The `history, session-end` pairing existed because the pre-Quiet-Mode world needed a second human tag for the `--log` PR flow. Once Quiet Mode went away, that hole should have been closed in #144 but was patched with an invented tag instead. When removing a feature, walk every dual-mapping it touched to confirm it collapses to a single primary.
- **Tier-1 mechanical-cleanup PRs still warrant in-line scope expansion under the implementation-issue rule.** The shiplog capture rubric treats discovered inconsistencies as implementation-issues, not automatic follow-ups, when (a) the fix is the same tier of edit and (b) splitting would leave the repo in an inconsistent intermediate state.

---

Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)
Updated-by: claude/opus-4.7 (claude-code)
*Captain's log -- PR timeline by [shiplog](https://github.com/devallibus/shiplog)*

