### PR TITLE
fix(#154): use <default-branch> in SKILL.md Step 2 walkthrough

### DIFF
--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -57,11 +57,11 @@ Apply lifecycle label: `gh issue edit 999 --add-label "shiplog/ready"`
 
 ### Step 2 — Branch Setup (`/shiplog start`)
 
-Load `commands/shiplog/start.md`. Create the branch from master tip:
+Load `commands/shiplog/start.md`. Create the branch from the default branch tip (substitute your repo's default branch, e.g. `main` or `master`):
 
 ```bash
-git fetch origin master
-git checkout -b issue/999-rate-limit-headers origin/master
+git fetch origin <default-branch>
+git checkout -b issue/999-rate-limit-headers origin/<default-branch>
 ```
 
 Swap label and update envelope:


### PR DESCRIPTION
## Summary

Restores the **shiplog** golden-path walkthrough to use the `<default-branch>` placeholder instead of a hardcoded `master`. PR #152 (SKILL.md restructure) introduced `git fetch origin master` and `origin/master` in Step 2, which fails in repos whose default branch is `main` (or any non-`master` name) and conflicts with `commands/shiplog/start.md` policy.

Flagged as P1 by Codex in [review 4134341205](https://github.com/devallibus/shiplog/pull/152#pullrequestreview-4134341205). Issue #8 previously addressed the same class of regression elsewhere; this re-applies the convention to the newly restructured walkthrough.

## Changes

`skills/shiplog/SKILL.md` — Step 2 walkthrough:

- Prose: "Create the branch from master tip:" → "Create the branch from the default branch tip (substitute your repo's default branch, e.g. `main` or `master`):"
- `git fetch origin master` → `git fetch origin <default-branch>`
- `git checkout -b issue/999-rate-limit-headers origin/master` → `...origin/<default-branch>`

Matches the `<default-branch>` placeholder used throughout `commands/shiplog/start.md:35-42` and the branch-base checklist at line 78.

## Timeline

- [shiplog/session-start] #154: branch cut from `origin/master`, T1 scoped
- [shiplog/commit-note] `a735024` — fix(#154/T1): use <default-branch> in Step 2 walkthrough

## Verification

- `grep -n "origin master\|origin/master" skills/shiplog/SKILL.md` → no matches
- Remaining `master` mentions: only the parenthetical example clarifying valid substitutions (intentional)
- Walkthrough now reads as a template that works for any default branch

## Links

- Closes #154
- Parent (regressing) PR: #152
- Codex review: https://github.com/devallibus/shiplog/pull/152#pullrequestreview-4134341205
- Related history: #8

Authored-by: claude/opus-4.7 (claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
