### PR TITLE
chore(#156/T1): bump plugin.json version to 0.5.0 (backfill)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shiplog",
   "description": "Git-as-knowledge-graph workflow for traceability across issues, branches, commits, reviews, and PRs.",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "author": {
     "name": "devallibus"
   },


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 156
branch: issue/156-bump-plugin-version-to-0.5.0
status: in-progress
updated_at: 2026-04-22T00:00:00Z
-->

## Summary

Bumps `.claude-plugin/plugin.json` `version` from `0.1.0` to `0.5.0` so existing consumer caches refresh and pick up the cumulative drift since 2026-03-15. This is **T1 of #156** only — the policy / CI / release workflow tasks (T2, T3, T4) follow as separate PRs so each is reviewable independently.

Addresses #156 (completes T1)

The version `0.5.0` was derived by classifying every PR merged to `master` since the implicit `0.1.0` baseline (PR #84, 2026-03-15) and grouping them into the natural release phases that would have shipped if version-bump policy had been in place from the start. See "Backfill audit" below for the per-phase rationale.

## Journey Timeline

### What we discovered
- `plugin.json` `version` has been pinned at `0.1.0` since 2026-03-15 even though 26 merged PRs since then have substantively changed `commands/`, `skills/`, and `.claude-plugin/`. Both Claude Code's plugin cache and `npx skills add` use that string as the refresh signal, so installs pinned at `0.1.0` keep running pre-fix snapshots forever. The most visible victim is the post-#151 / #140 hunt-command fix, which never reached existing users.
- Only three commits ever touched `plugin.json` (initial scaffold, `skills` field, `commands` field). None bumped the version.

### Decisions
| Decision | Choice | Why |
|----------|--------|-----|
| Target version | `0.5.0` | Five MINOR-worthy phases since 0.1.0 (see audit). Stays on 0.x because the surface is still mobile (Quiet Mode just removed; vocabulary just rewritten). 1.0.0 is a future stability declaration, not a drift-catchup release. |
| Scope of this PR | T1 only — version bump | Each of T2 (CONTRIBUTING policy), T3 (CI bump-check), T4 (release workflow) deserves its own focused review. Bundling would obscure the policy decisions that future maintainers will revisit. |
| Tag/release | Created post-merge as part of T1 verification | T4 (the release workflow) does not exist yet, so the first `v0.5.0` tag and release will be cut manually via `gh release create v0.5.0 --notes-file <file>` once this PR merges. The next bump will go through T4 once it lands. |

## Backfill audit (rationale for `0.5.0`)

| Phase | When | PRs (MINOR-worthy bold) | Why MINOR |
|-------|------|------------------------|-----------|
| **0.2.0** initial conventions | Mar 15 morning | **#86, #82, #98, #94** (+ patches #81, #90, #89, #100) | New label vocabulary, task-ID convention, partial-delivery semantics, mode routing, self-audit profile, brand rule |
| **0.3.0** slash commands | Mar 15 afternoon | **#110** (+ patches #118, #112) | Introduced the `commands/` slash-command surface; `commands` field added to `plugin.json` |
| **0.4.0** review / hunt workflow | Mar 19 | **#126, #115, #133, #121, #127, #125** | Identity-aware hunt, PR-body review snapshot, `Last-code-by` field, `approve-with-follow-ups` disposition, internalized commit/PR workflows |
| 0.4.1 patch | Mar 24 | #136, #138 | Docs only |
| **0.5.0** skill simplification | Apr 18 | **#148, #149, #151, #152, #153** (+ patch #155) | Removed Quiet Mode (BREAKING in 0.x), vocabulary triad rewrite, hunt fix from #140, SKILL.md golden-path restructure, removed invented tags |

Net: five MINOR-worthy release phases → land at `0.5.0`. The post-#155 patch effectively rolls into this single drift-catchup release.

## Changes

- Edit `.claude-plugin/plugin.json`: `"version": "0.1.0"` → `"version": "0.5.0"`

That's the entire diff for this PR.

## Testing / Verification

Per #156 T1's verification step:

1. After merge, cut the tag and release:
   ```bash
   gh release create v0.5.0 --notes-file <release-notes>
   ```
   (Release notes draft prepared in #156 will be pasted in.)
2. From a clean machine (or with the local plugin cache cleared), reinstall via the path documented in README:
   ```bash
   npx skills add devallibus/shiplog --skill shiplog
   ```
3. Confirm the post-#151 hunt scan-comments behavior is now present:
   ```bash
   grep -c 'gh pr view <N> --json comments' ~/.claude/commands/shiplog/hunt.md
   # should return: 1
   ```
4. Confirm `commands/` directory is part of the install (it isn't on the existing `0.1.0` snapshot).

## Knowledge for Future Reference

- `plugin.json` `version` is the cache key for the Claude Code plugin manager (`~/.claude/plugins/cache/<plugin>/<plugin>/<version>/`). Without bumping it, cache-keyed installs never refresh, and `npx skills add` similarly sees no upgrade signal. Treat the `version` field as the externally-visible release pointer — not as decoration.
- This bump intentionally skips intermediate releases. The next bump under the new policy (T2/T3/T4) increments per-PR per the rules documented in CONTRIBUTING.
- Three Open Questions on #156 are still pending and may revise this approach: (1) `0.5.0` vs `1.0.0`, (2) MAJOR-vs-MINOR for removals while in 0.x, (3) whether `npx skills add` honors Git tags as version pins. None of those block this PR — they shape the policy doc in T2.

---
Authored-by: claude/opus-4.7 (claude-code)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
