### PR TITLE
docs(#156/T2): add CONTRIBUTING.md with versioning policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to shiplog
+
+Thanks for contributing. This file documents the project conventions a contributor or AI agent needs to know before opening a PR.
+
+## Versioning
+
+**shiplog** follows [semver](https://semver.org/). The version field that matters lives in `.claude-plugin/plugin.json`. It is the cache key used by Claude Code's plugin manager and by `npx skills add` to decide whether to refresh installed copies — so without a bump, downstream installs never see your change.
+
+### Bump rule
+
+If your PR touches any path under:
+
+- `commands/`
+- `skills/`
+- `.claude-plugin/`
+
+then your PR **must** include a `version` bump in `.claude-plugin/plugin.json`. CI enforces this (see `.github/workflows/version-bump-check.yml`).
+
+PRs that only touch other paths (README, CONTRIBUTING, `.github/`, `LICENSE`, etc.) do not need a bump.
+
+### Choosing the bump
+
+While we are on `0.x.y`:
+
+| Change | Bump |
+|--------|------|
+| New slash command, new skill file, new envelope kind, new label, new disposition, removed or renamed slash command, removed skill | MINOR (`0.X.0`) |
+| Wording changes inside an existing skill or command, doc-only updates, internal cleanups that preserve the documented surface | PATCH (`0.x.Y`) |
+
+In `0.x` there is no MAJOR — every breaking change is a MINOR per semver §4. Once we declare `1.0.0`, breaking changes become MAJOR and the rule above shifts accordingly.
+
+### Releases
+
+Each version bump on `master` triggers a Git tag and a GitHub Release automatically (see `.github/workflows/release.yml`). The release notes are auto-generated from PRs merged since the previous tag.
+
+If the release workflow is missing or fails, cut the release manually:
+
+```bash
+gh release create vX.Y.Z --notes-file <release-notes-file> --target master
+```
+
+## Workflow
+
+**shiplog** dogfoods its own workflow. See [`skills/shiplog/SKILL.md`](skills/shiplog/SKILL.md) for the full conventions: ID-first branches, signed artifacts, cross-model review, and evidence-linked closure.
+
+Key contributor expectations:
+
+- Branch from `master` as `issue/<id>-<slug>`.
+- Commit subjects use `<type>(#<id>): <msg>` or `<type>(#<id>/<Tn>): <msg>` for task-scoped commits.
+- PR body follows the template in [`skills/shiplog/pr.md`](skills/shiplog/pr.md): envelope, summary, journey timeline, changes, verification, knowledge for future reference.
+- Sign every shiplog artifact (PR body, signed comments, review comments) with `<role>: <family>/<version> (<tool>)`.
+- Cross-model review is required before merge. See [`skills/shiplog/references/closure-and-review.md`](skills/shiplog/references/closure-and-review.md) §3.
+
+## Asking for help
+
+Open an issue with the `shiplog/plan` label and describe what you are trying to do. The maintainer (or the next agent that runs `/shiplog:hunt`) will pick it up.

--- a/README.md
+++ b/README.md
@@ -317,6 +317,10 @@ Both optional. **shiplog** works without any configuration.
 | `superpowers:writing-plans` | Superpowers | Structured plan documents |
 | `superpowers:executing-plans` | Superpowers | Plan execution with checkpoints |
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for project conventions, including the `plugin.json` versioning rule that gates content PRs.
+
 ## License
 
 MIT


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 156
branch: issue/156-T2-contributing-versioning
status: in-progress
updated_at: 2026-04-22T00:00:00Z
-->

## Summary

Adds `CONTRIBUTING.md` with the canonical versioning policy from #156, and links it from `README.md` so contributors and agents can find the bump rule before opening a PR.

Addresses #156 (completes T2)

## Journey Timeline

### Decisions
- **Path list lives in CONTRIBUTING.md, not in CI text.** The CI check (T3) and the docs (T2) need to agree on which paths trigger a bump. Documenting the list in CONTRIBUTING.md as the source of truth keeps the rule searchable; T3's workflow will reference the same three paths (`commands/`, `skills/`, `.claude-plugin/`).
- **Stay on the 0.x semver rule for now.** Per semver §4, while in `0.x` there is no MAJOR — every breaking change is MINOR. CONTRIBUTING.md states this explicitly so reviewers do not request "MAJOR for breaking changes" before `1.0.0` is declared. When `1.0.0` lands, the table updates.
- **README link, not duplicated content.** README only adds a one-line Contributing section pointing at the file; the policy itself lives in one place.

## Changes

- Create `CONTRIBUTING.md`: Versioning rules (which paths trigger a bump, semver while in 0.x, manual release fallback) and a Workflow pointer to `skills/shiplog/SKILL.md`.
- `README.md`: add `## Contributing` section before `## License`, linking to CONTRIBUTING.md.

## Testing / Verification

- The new `## Contributing` section in README links to `CONTRIBUTING.md` (relative path resolves on github.com).
- CONTRIBUTING.md names all three trigger paths in one section (`commands/`, `skills/`, `.claude-plugin/`) so they can be quoted directly into the T3 workflow.
- No `commands/`, `skills/`, or `.claude-plugin/` paths touched in this PR — no version bump required (and the policy this PR documents would not require one).

## Knowledge for Future Reference

- T3 (CI bump-check) and T4 (release workflow) will both reference this file for the bump-trigger path list. If the list changes, update CONTRIBUTING.md first and have CI / release workflows quote it (or grep against it).
- If `1.0.0` is declared later, the bump-table here is the spot to update — it is the single source of truth for "what counts as MAJOR vs MINOR vs PATCH" in this repo.

---
Authored-by: claude/opus-4.7 (claude-code)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
