### PR TITLE
ci(#156/T3): add version-bump-check workflow

### DIFF
--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -1,0 +1,80 @@
+# Enforces the versioning policy from CONTRIBUTING.md:
+# any PR that touches commands/, skills/, or .claude-plugin/ must bump
+# .claude-plugin/plugin.json `version`. The version field is the cache key
+# downstream installs (Claude Code plugin manager, npx skills add) use to
+# decide whether to refresh — without a bump, fixes never reach consumers.
+#
+# Implementation: pure shell + jq, no third-party action. Runs on PRs only.
+
+name: Version bump check
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify plugin.json version bump on gated paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Path list mirrors CONTRIBUTING.md "Versioning" section.
+          # Update both together if the trigger paths change.
+          gated_prefixes=(commands/ skills/ .claude-plugin/)
+
+          changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+
+          gated_hit=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            for p in "${gated_prefixes[@]}"; do
+              case "$f" in
+                "$p"*) gated_hit="$f"; break ;;
+              esac
+            done
+            [ -n "$gated_hit" ] && break
+          done <<<"$changed"
+
+          if [ -z "$gated_hit" ]; then
+            echo "No gated paths changed; version bump not required."
+            exit 0
+          fi
+
+          echo "Gated path changed (e.g. $gated_hit). Checking plugin.json version..."
+
+          base_version=$(git show "$BASE_SHA:.claude-plugin/plugin.json" | jq -r .version)
+          head_version=$(git show "$HEAD_SHA:.claude-plugin/plugin.json" | jq -r .version)
+
+          echo "  base version: $base_version"
+          echo "  head version: $head_version"
+
+          if [ "$base_version" = "$head_version" ]; then
+            echo
+            echo "::error file=.claude-plugin/plugin.json::PR touches gated paths but plugin.json version is unchanged ($base_version)."
+            cat <<'MSG'
+
+          This PR changes paths under commands/, skills/, or .claude-plugin/
+          but does not bump .claude-plugin/plugin.json `version`.
+
+          Without a version bump, downstream installs (Claude Code plugin
+          cache, npx skills add) will not refresh and your change will be
+          invisible to consumers.
+
+          See CONTRIBUTING.md "Versioning" section for the bump rule and
+          the semver guidance for choosing MINOR vs PATCH while in 0.x.
+          MSG
+            exit 1
+          fi
+
+          echo "Version bumped from $base_version to $head_version."


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 156
branch: issue/156-T3-ci-version-bump-check
status: in-progress
updated_at: 2026-04-22T00:00:00Z
-->

## Summary

Adds a GitHub Actions workflow that fails any PR which touches `commands/`, `skills/`, or `.claude-plugin/` without bumping `.claude-plugin/plugin.json` `version`. Mechanically enforces the policy from #156 / T2 so cumulative drift cannot recur silently.

Addresses #156 (completes T3)

## Journey Timeline

### Decisions
| Decision | Choice | Why |
|----------|--------|-----|
| Implementation | Pure shell + jq, no third-party action | Diff + JSON parse is short enough to read inline; pinning a third-party action would add a supply-chain dependency for no benefit. |
| Trigger paths | `commands/`, `skills/`, `.claude-plugin/` | Same list documented in CONTRIBUTING.md (T2). The workflow header explicitly notes the two must stay in sync. |
| Diff base | `git diff $BASE...$HEAD` (three-dot) | Diffs against the merge-base of the PR rather than the literal base SHA, so up-to-date branches don't false-positive. |
| Escape hatches | None | The whole point is mechanical enforcement. If a real exemption appears, it's a CONTRIBUTING.md policy change, not a CI bypass. |
| Failure UX | `::error file=...::` annotation + multi-line explainer in the log | The annotation surfaces in the GitHub PR UI; the explainer points at CONTRIBUTING.md so authors know how to fix it. |

## Changes

- Create `.github/workflows/version-bump-check.yml`: runs on `pull_request` to `master`, checks out with `fetch-depth: 0`, walks the diff, and fails when a gated path changed but `plugin.json` `version` did not.

That is the entire diff for this PR.

## Testing / Verification

I cannot execute Actions from this PR's body; the verification plan post-merge is:

1. Open a throwaway PR that edits one file under `skills/` without changing `plugin.json`. Expect the new check to fail with the annotation pointing at `.claude-plugin/plugin.json` and the multi-line explainer in the log.
2. Push a follow-up commit to the same PR that bumps `plugin.json` version. Expect the check to pass.
3. Open another throwaway PR that only edits `README.md`. Expect the check to pass without examining `plugin.json` (logs should print "No gated paths changed; version bump not required.").

If any of those misbehave, the workflow is straightforward to revert with a one-file removal.

## Knowledge for Future Reference

- The trigger path list is duplicated between the workflow header and CONTRIBUTING.md. T4 (release workflow) should similarly reference the same list when generating release notes that group changes by impact area. If a new top-level path becomes a gated surface, update CONTRIBUTING.md first, then mirror in this workflow.
- Pure-shell approach was chosen so a maintainer can read the entire enforcement logic in 30 seconds. If future requirements grow (e.g. semver direction check, monorepo per-package versioning), revisit whether to migrate to a published action or a small composite action.
- The workflow only touches `.github/workflows/`, which is **not** a gated path under the policy itself. So this PR does not need a version bump (and the absence of one demonstrates the rule's negative case).

---
Authored-by: claude/opus-4.7 (claude-code)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
