### PR TITLE
fix(#161): de-hardcode master in CONTRIBUTING and CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,11 @@ name: Release on version change
 
 on:
   push:
-    branches: [master]
+    # List both master and main so a future default-branch rename does
+    # not silently stop publishing releases. GitHub Actions does not
+    # template `branches:`, so a literal list is the simplest correct
+    # shape.
+    branches: [master, main]
     paths: ['.claude-plugin/plugin.json']
 
 permissions:

--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -10,7 +10,10 @@ name: Version bump check
 
 on:
   pull_request:
-    branches: [master]
+    # List both master and main so a future default-branch rename does
+    # not silently no-op the check. GitHub Actions does not template
+    # `branches:`, so a literal list is the simplest correct shape.
+    branches: [master, main]
 
 jobs:
   check:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,12 +31,12 @@ In `0.x` there is no MAJOR — every breaking change is a MINOR per semver §4. 
 
 ### Releases
 
-Each version bump on `master` triggers a Git tag and a GitHub Release automatically (see `.github/workflows/release.yml`). The release notes are auto-generated from PRs merged since the previous tag.
+Each version bump on the default branch triggers a Git tag and a GitHub Release automatically (see `.github/workflows/release.yml`). The release notes are auto-generated from PRs merged since the previous tag.
 
 If the release workflow is missing or fails, cut the release manually:
 
 ```bash
-gh release create vX.Y.Z --notes-file <release-notes-file> --target master
+gh release create vX.Y.Z --notes-file <release-notes-file> --target <default-branch>
 ```
 
 ## Workflow
@@ -45,7 +45,7 @@ gh release create vX.Y.Z --notes-file <release-notes-file> --target master
 
 Key contributor expectations:
 
-- Branch from `master` as `issue/<id>-<slug>`.
+- Branch from your `<default-branch>` as `issue/<id>-<slug>`.
 - Commit subjects use `<type>(#<id>): <msg>` or `<type>(#<id>/<Tn>): <msg>` for task-scoped commits.
 - PR body follows the template in [`skills/shiplog/pr.md`](skills/shiplog/pr.md): envelope, summary, journey timeline, changes, verification, knowledge for future reference.
 - Sign every shiplog artifact (PR body, signed comments, review comments) with `<role>: <family>/<version> (<tool>)`.


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 161
branch: issue/161-default-branch-language
status: resolved
updated_at: 2026-04-22T00:00:00Z
-->

## Summary

Fixes the two cohesion regressions codex flagged on PRs #158/#159/#160 after they had already been squash-merged: hardcoded `master` references in CONTRIBUTING.md instructions and in both new GitHub Actions workflows.

Closes #161

## Journey Timeline

### What we discovered (post-merge)
After the four-PR #156 batch was merged in rapid succession, the codex bot completed its review and posted P1 line-comments on the three closed PRs:

- **#158 / CONTRIBUTING.md line 48:** "Branch from `master`" hardcodes a branch name; the project moved to `<default-branch>` language in PR #155 four days earlier.
- **#159 / version-bump-check.yml line 13:** `branches: [master]` filter would silently no-op if the repo were ever renamed to `main`.
- **#160 / release.yml line 15:** same `branches: [master]` brittleness on the release workflow.

Codex's stated premise (that shiplog's default branch is `main`) is **wrong** — `gh repo view` confirms the default is `master`, so today the workflows do fire as intended. But the broader concern is correct: the project's own `<default-branch>` convention from PR #155 was just split again, and a future rename would silently break CI.

### Decisions
| Decision | Choice | Why |
|----------|--------|-----|
| Workflow fix shape | `branches: [master, main]` literal list | GitHub Actions does not template the `branches:` filter, so two-branch literal is the simplest correct shape. Cheap belt-and-suspenders that survives a rename. |
| Doc fix shape | `<default-branch>` placeholder | Matches the convention SKILL.md adopted in PR #155. Keeps the project consistent with itself. |
| Process learning | Wait for codex before merging shiplog PRs | Comment block in this PR body. Future shiplog PRs should give the bot at least 2 minutes after open before merging, OR explicitly comment `@codex review` after merge to backfill. We are doing the former on this one. |

## Changes

- `CONTRIBUTING.md`:
  - "Branch from `master`" → "Branch from your `<default-branch>`".
  - "Each version bump on `master` triggers..." → "Each version bump on the default branch triggers...".
  - Manual release example: `--target master` → `--target <default-branch>`.
- `.github/workflows/version-bump-check.yml`: `branches: [master]` → `branches: [master, main]` with an inline comment explaining the rationale.
- `.github/workflows/release.yml`: same change with the same explanatory comment.

No changes under `commands/`, `skills/`, or `.claude-plugin/` — so the version-bump-check workflow this PR adjusts will pass without a `plugin.json` bump (and the absence of one is intentional and documents that the workflow exempts non-gated paths correctly).

## Testing / Verification

- Diff is three files, all small, scoped exactly to the codex findings.
- The version-bump-check workflow will run against this PR (it triggers on PRs to `master`, which is what this PR targets) and should pass since no gated paths changed.
- The release workflow does not run on PRs, only on push to master/main, so its behavior is verified next time `plugin.json` version is bumped.
- Spot-checked the diff for any other surviving "master" references in CONTRIBUTING.md / new workflows — none remain that are policy or instruction. (`README.md` mentions of "master" in unrelated narrative are out of scope here.)

## Knowledge for Future Reference

- **Process:** when opening multiple shiplog PRs in rapid succession, allow codex at least 2 minutes between open and merge so its line-level findings have time to land. The bot posts a "Reviewed commit: <SHA>" boilerplate immediately, then files findings (or a 👍 reaction) seconds-to-minutes later. Merging during that window means findings land on closed PRs.
- **Pattern:** the codex bot uses GitHub user `chatgpt-codex-connector[bot]` (with the `[bot]` suffix in the API). `gh pr view --jq '.author.login'` strips the suffix; the raw API does not. When automating bot-finding inspection, query the raw API to be sure.
- **Convention:** going forward, any new docs or CI in this repo that names a branch should use `<default-branch>` (docs) or list both `master, main` (CI `branches:` filters). PR #155 is the precedent.

---
Authored-by: claude/opus-4.7 (claude-code)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
