### PR TITLE
fix(#163): fold comments into hunt Step 2 pr-list call

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shiplog",
   "description": "Git-as-knowledge-graph workflow for traceability across issues, branches, commits, reviews, and PRs.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "devallibus"
   },

--- a/commands/shiplog/hunt.md
+++ b/commands/shiplog/hunt.md
@@ -43,15 +43,12 @@ gh issue list --state open --json number,title,labels --limit 30
 
 ### Step 2 — Fetch open PRs with comments
 
-Fetch the PR list including body, reviews, and commits:
+Fetch the PR list including body, reviews, commits, and comments in a single call so signed-review evidence is present from the first turn:
 ```bash
-gh pr list --state open --json number,title,isDraft,reviewDecision,reviews,body,url,headRefName --limit 20
+gh pr list --state open --json number,title,isDraft,reviewDecision,reviews,body,url,headRefName,comments,commits --limit 20
 ```
 
-Then for **each open PR**, fetch comments to detect signed reviews:
-```bash
-gh pr view <N> --json comments,commits
-```
+`comments` and `commits` are supported `gh pr list` JSON fields, so one call returns every open PR's top-level comment thread — where signed `Reviewed-by:` / `Disposition:` artifacts live. If the payload is truncated (very large repos, very long comment threads), fall back to a per-PR `gh pr view <N> --json comments,commits` call for the affected PRs only.
 
 Signed-review detection — scan each comment body for both patterns:
 ```
@@ -159,7 +156,7 @@ Tier constraints:
 
 ## Acceptance Checklist
 
-- [ ] For every open PR, `gh pr view <N> --json comments` was fetched and scanned for `Reviewed-by:` + `Disposition:` lines before classifying review status
+- [ ] For every open PR, the `comments` payload (from the `gh pr list` call in Step 2, or a per-PR `gh pr view <N> --json comments` fallback when truncated) was scanned for `Reviewed-by:` + `Disposition:` lines before classifying review status
 - [ ] No PR with a valid signed `Disposition: approve` comment appears in the "needs review" bucket
 - [ ] No PR with `Disposition: request-changes` is classified as approved
 - [ ] Each PR's last-code author was resolved via the fallback chain (not assumed from `Authored-by:` alone)


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 163
branch: issue/163-hunt-comments-in-list
status: resolved
updated_at: 2026-04-22T00:00:00Z
-->

## Summary

Folds `comments` and `commits` into the Step 2 `gh pr list` call in `commands/shiplog/hunt.md` so signed-review evidence arrives in the first pr-list payload, not in a per-PR fallback. Turns the prior N+1 API pattern (one list + one `gh pr view` per PR) into a single list call, and re-scopes the per-PR `gh pr view` to truncation recovery only. Bumps plugin.json to `0.5.1` so downstream installs refresh.

Closes #163.

## Journey Timeline

### What prompted the fix

During a `/shiplog:hunt` run on `devallibus/pogbeasts`, PR #161 (which already carried three signed `Reviewed-by: claude/opus-4.7 (claude-code)` comments) was mis-classified as "no signed review." Investigation showed the installed `commands/shiplog/hunt.md` relied on the per-PR `gh pr view` call to discover comment-based signed reviews, and the runtime skipped that step after seeing a complete-looking list payload.

The post-#140 / post-#151 prompt text correctly instructs the model to scan `comments` in Step 2, but leaves the data fetch split into two calls. Because `gh pr list` supports `comments` as a JSON field, the split was unnecessary and failure-prone.

### What changed

- `commands/shiplog/hunt.md` Step 2: single `gh pr list --state open --json number,title,isDraft,reviewDecision,reviews,body,url,headRefName,comments,commits --limit 20` call; per-PR `gh pr view` explicitly labeled as truncation fallback.
- Acceptance checklist item 1 reworded to match the new default path plus fallback.
- `.claude-plugin/plugin.json` `version`: `0.5.0` → `0.5.1`.

## Changes

- `ef5503b` `fix(#163): fold comments into hunt Step 2 pr-list call`

## Testing / Verification

- Manually verified `gh pr list --state open --json ...,comments,commits --limit 5` against `devallibus/pogbeasts` returns every open PR's comment bodies in one call, including the three signed `Reviewed-by:` artifacts on PR #161.
- Version bump matches CONTRIBUTING.md gating rule; `version-bump-check.yml` will pass on this PR.
- No tests or scripts reference the prior two-call shape; `grep -R "gh pr view <N>" skills/ commands/` returns only the updated fallback line.

## Knowledge For Future Reference

- `gh pr list --json` accepts `comments` and `commits` — future commands should prefer one list call over a list + per-PR view fan-out when the field list supports it.
- The versioning policy from #156 now has real teeth: any change under `commands/`, `skills/`, or `.claude-plugin/` must bump plugin.json or CI fails. Bumping as part of the same PR is the cheap path.
- Review gate note: the user explicitly authorized bypassing the cross-model review gate for this PR so the 0.5.1 release can ship immediately. Future PRs to `shiplog` should resume the standard cross-model review before merge.

---
Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)
*Captain's log — PR timeline by **shiplog***
