### PR TITLE
docs: fix cross-references, phase index, and duplicated blocks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shiplog",
   "description": "Git-as-knowledge-graph workflow for traceability across issues, branches, commits, reviews, and PRs.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {
     "name": "devallibus"
   },

--- a/.github/workflows/cross-ref-check.yml
+++ b/.github/workflows/cross-ref-check.yml
@@ -1,0 +1,34 @@
+# Rejects legacy cross-reference forms that the audit found drifting:
+# bare `shiplog:<skill>` references outside HTML envelopes. Shiplog's own
+# units are referenced by file path; the `plugin:skill` syntax is reserved
+# for external plugins (e.g. `ork:commit`, `superpowers:brainstorming`).
+#
+# Implementation: pure shell + grep, no third-party action. Runs on PRs only.
+
+name: Cross-reference check
+
+on:
+  pull_request:
+    # List both master and main so a future default-branch rename does
+    # not silently no-op the check. GitHub Actions does not template
+    # `branches:`, so a literal list is the simplest correct shape.
+    branches: [master, main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Reject legacy shiplog:skill refs outside envelopes
+        shell: bash
+        run: |
+          set -euo pipefail
+          # '<!-- shiplog:' opens an envelope; any bare shiplog:<skill> is legacy.
+          if grep -rnE '(^|[^!:-])shiplog:[a-z]+' skills commands --include='*.md' \
+             | grep -vE '<!-- shiplog:'; then
+            echo "::error::Legacy 'shiplog:<skill>' reference found. Use a file path instead."
+            exit 1
+          fi
+          echo "OK: no legacy shiplog:<skill> references."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Key contributor expectations:
 
 - Branch from your `<default-branch>` as `issue/<id>-<slug>`.
 - Commit subjects use `<type>(#<id>): <msg>` or `<type>(#<id>/<Tn>): <msg>` for task-scoped commits.
-- PR body follows the template in [`skills/shiplog/pr.md`](skills/shiplog/pr.md): envelope, summary, journey timeline, changes, verification, knowledge for future reference.
+- PR body follows the template in [`skills/shiplog/pr.md`](skills/shiplog/pr.md): envelope, summary, journey timeline, changes, verification, knowledge for future reference. (The runnable PR policy lives in `commands/shiplog/pr.md`; the template alone is here.)
 - Sign every shiplog artifact (PR body, signed comments, review comments) with `<role>: <family>/<version> (<tool>)`.
 - Cross-model review is required before merge. See [`skills/shiplog/references/closure-and-review.md`](skills/shiplog/references/closure-and-review.md) §3.
 

--- a/commands/shiplog/pr.md
+++ b/commands/shiplog/pr.md
@@ -21,7 +21,7 @@ Push the branch and create a PR whose body is a complete timeline of the work: i
 Authored-by: <family>/<version> (<tool>)
 Last-code-by: <family>/<version> (<tool>)
 ```
-`Last-code-by:` is updated whenever new code is pushed to the branch after PR creation. See SKILL.md §8 for code provenance rules.
+`Last-code-by:` is updated whenever new code is pushed to the branch after PR creation. See SKILL.md → "Agent Identity Signing" for code provenance rules.
 
 **Review gate:** do NOT merge until a cross-model `Reviewed-by:` + `Disposition: approve` (or `approve-with-follow-ups`) comment exists on the PR. Self-review does not satisfy the gate. See `commands/shiplog/review.md` for the full review sub-skill, and `references/closure-and-review.md` §3 for the cross-model gate policy.
 

--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -17,7 +17,7 @@ Use GitHub as a complete knowledge graph where every brainstorm, commit, review,
 
 ## Golden-Path Walkthrough
 
-A complete issue-to-merge example using a concrete fake issue `#999`. Follow this sequence and every artifact produced will pass the acceptance checklists in `commands/shiplog/*.md`.
+A complete issue-to-merge example using a concrete fake issue `#999`. Follow this sequence and every artifact produced will pass the acceptance checklists in `commands/shiplog/*.md`. The blocks here are illustrative; the canonical, copy-ready templates live in the phase sub-skills under `skills/shiplog/` (see the Phase Sub-skill Index) and in `references/`. If a template changes, verify this walkthrough example is updated to match.
 
 ### Step 1 — Plan Capture (`/shiplog plan`)
 
@@ -190,10 +190,17 @@ Cross-model gate is satisfied (`Last-code-by: claude/sonnet-4.6` ≠ `Reviewed-b
 
 ## Verb Grid
 
-Each `/shiplog <phase>` slash command maps to one sub-skill file. Load the file for that phase — it owns policy, templates, and acceptance checklist.
+Each `/shiplog <command>` slash command maps to one command file under `commands/shiplog/`. Load the command file — it owns the phase's runnable policy, templates, and acceptance checklist.
 
-| Command | What it does | Sub-skill |
-|---------|-------------|-----------|
+Two trees co-exist and complement each other:
+
+- `commands/shiplog/*.md` — the slash commands (`plan`, `start`, `hunt`, `commit`, `pr`, `review`, `lookup`, `resume`, `models`). Executable policy: runnable queries, allowed tools, acceptance checklists.
+- `skills/shiplog/*.md` — the phase sub-skills (`brainstorm`, `branch`, `discovery`, `commit`, `pr`, `lookup`, `timeline`). Template library + routing annotations; referenced by phase, not invoked as commands.
+
+The phase sub-skills are indexed below in "Phase Sub-skill Index". Open a phase sub-skill when you need its template or checklist; open the matching command file when you are about to execute that phase.
+
+| Command | What it does | Command file |
+|---------|-------------|--------------|
 | `/shiplog plan` | Capture a brainstorm as a GitHub planning issue with envelope + task contracts | `commands/shiplog/plan.md` |
 | `/shiplog start` | Create a branch from an issue, swap lifecycle labels, post session-start comment | `commands/shiplog/start.md` |
 | `/shiplog hunt` | Triage open issues and PRs; rank by readiness; detect gate-satisfying reviews | `commands/shiplog/hunt.md` |
@@ -204,6 +211,24 @@ Each `/shiplog <phase>` slash command maps to one sub-skill file. Load the file 
 | `/shiplog resume` | Re-orient to current branch; detect issue number; post session-resume comment | `commands/shiplog/resume.md` |
 
 **`/shiplog models`:** Re-runs the model-routing setup prompt. See `references/model-routing.md`.
+
+---
+
+## Phase Sub-skill Index
+
+The phase sub-skills under `skills/shiplog/` carry templates, routing annotations, and acceptance checklists per phase. They are keyed the same way the command files are keyed, but are loaded by phase (look up the template you need), not invoked as slash commands.
+
+| Phase | Sub-skill | Holds templates for |
+|-------|-----------|---------------------|
+| 1. Brainstorm   | `skills/shiplog/brainstorm.md` | Issue creation, task contracts, plan envelope |
+| 2. Branch Setup | `skills/shiplog/branch.md`     | Session-start comment, delegation handoffs |
+| 3. Discovery    | `skills/shiplog/discovery.md`  | Discovery issues, blocker cross-reference comments, stacked-PR flow |
+| 4. Commit       | `skills/shiplog/commit.md`     | Commit-context comments |
+| 5. PR           | `skills/shiplog/pr.md`         | PR timeline body (full + partial delivery) |
+| 6. Lookup       | `skills/shiplog/lookup.md`     | Retrieval results, triage-scan output formats |
+| 7. Timeline     | `skills/shiplog/timeline.md`   | Session-start/resume, milestone, blocker, closure artifacts |
+
+**Single source of truth:** `references/phase-templates.md` is a compatibility pointer that indexes the same files; keep this index and that pointer in sync. See `references/closure-and-review.md` for the review sign-off template (owned there, cross-referenced from `skills/shiplog/pr.md`).
 
 ---
 
@@ -468,7 +493,7 @@ The timeline comment is the minimum: one paragraph explaining what happened, why
 ## Edge Cases
 
 - **No issue exists:** Let the user work. At first commit or PR, offer to create a tracking issue.
-- **Mid-work activation:** Check branch name for `issue/N-*`. If found, add catch-up timeline comment via `shiplog:timeline`. If not, offer retroactive issue creation.
+- **Mid-work activation:** Check branch name for `issue/N-*`. If found, add catch-up timeline comment via `skills/shiplog/timeline.md`. If not, offer retroactive issue creation.
 - **Small tasks (< 30 min):** Lightweight protocol - issue optional, branch still created, PR sections can be brief.
 - **Hotfix / emergency:** Fix first. Create issue and PR after, backfilling the timeline.
 - **Post-merge cleanup:** Remove a worktree only when its branch is merged, no open PR still depends on it, and it is not the active workspace. See `references/orchestrator-protocol.md`.
@@ -504,12 +529,14 @@ Key rules:
 
 ### Integration Map
 
-This skill ORCHESTRATES. Sub-skills under `commands/shiplog/` each own their phase's policy, runnable queries, and acceptance checklist in a single file — no cross-file navigation required during execution. References in `references/` are deep-dive anchors for cross-cutting policy only.
+This skill ORCHESTRATES. Command files under `commands/shiplog/` each own their phase's policy, runnable queries, and acceptance checklist in a single file — no cross-file navigation required during execution. References in `references/` are deep-dive anchors for cross-cutting policy only.
 
-#### Sub-skill map
+Alongside the command files, `skills/shiplog/*.md` are the phase sub-skills carrying templates and routing annotations (open them by phase — see "Phase Sub-skill Index"). The command file is the executable entry point for a phase; the phase sub-skill is its template/checklist companion. Where both exist under the same name (`commit`, `pr`, `lookup`), they are distinct: `commands/` = runnable policy, `skills/` = template library.
 
-| Phase | Sub-skill | Owns |
-|-------|-----------|------|
+#### Command map
+
+| Phase | Command file | Owns |
+|-------|--------------|------|
 | Plan Capture | `commands/shiplog/plan.md` | Brainstorm-to-issue policy, gh issue create template, envelope requirements |
 | Branch Setup | `commands/shiplog/start.md` | Branch naming, label swap, session-start comment template |
 | Triage / Hunt | `commands/shiplog/hunt.md` | PR+issue triage, signed-review detection (comment-based), reviewability classification |
@@ -527,7 +554,8 @@ This skill ORCHESTRATES. Sub-skills under `commands/shiplog/` each own their pha
 | Merge conditions | `references/closure-and-review.md` §5 | Gate satisfaction conditions; risk-based requirements |
 | Closure evidence | `references/closure-and-review.md` §1–2 | Evidence requirements; closure comment format |
 | Envelope schema | `references/artifact-envelopes.md` §1 | Triage field derivation rule; field definitions |
-| Signing spec | `SKILL.md §8` | Authored-by / Updated-by / Reviewed-by / Last-code-by rules |
+| Signing spec | `SKILL.md → "Agent Identity Signing"` | Authored-by / Updated-by / Reviewed-by / Last-code-by rules |
+| Worktree cleanup | `references/orchestrator-protocol.md` | Canonical portable cleanup sequence (`skills/shiplog/branch.md` duplicates this block) |
 
 #### External skill delegation
 

--- a/skills/shiplog/brainstorm.md
+++ b/skills/shiplog/brainstorm.md
@@ -6,13 +6,13 @@ description: "Phase 1: Capture brainstorming output as a GitHub issue with struc
 # Plan Capture (Phase 1)
 
 <!-- routing: tier-1, plan -->
-<!-- cross-cutting: references/model-routing.md (Step 0), SKILL.md §8 (Agent Identity Signing), references/labels.md -->
+<!-- cross-cutting: references/model-routing.md (Step 0), SKILL.md → "Agent Identity Signing", references/labels.md -->
 
 0. **Routing check.** Run the phase entry check from `references/model-routing.md`. On first activation, if `.shiplog/routing.md` is missing, run the setup prompt first.
 
 1. **Run the brainstorm.** Follow `references/brainstorm-workflow.md` for the design exploration process. External skills (`superpowers:brainstorming`, `ork:brainstorming`) may be used for the exploration phase (steps 1-4) but output capture (steps 5-6) follows the internalized workflow.
 
-2. **Capture as GitHub Issue (Full Mode).** Before the first labeled create in a repo, bootstrap the Shiplog labels per `references/labels.md`. Create the issue with `shiplog/plan` already applied using the template below. Sign the issue body per the signing spec — see SKILL.md §8 (Agent Identity Signing).
+2. **Capture as GitHub Issue (Full Mode).** Before the first labeled create in a repo, bootstrap the Shiplog labels per `references/labels.md`. Create the issue with `shiplog/plan` already applied using the template below. Sign the issue body per the signing spec — see SKILL.md → "Agent Identity Signing".
 
    Before writing the final issue body, classify factual claims:
    - **Internal claims** about this repository's code, tests, configuration, or committed docs can be verified from the repo itself.
@@ -21,7 +21,7 @@ description: "Phase 1: Capture brainstorming output as a GitHub issue with struc
 
 3. **Store in knowledge graph.** If `ork:remember` is available, store the key decision.
 
-4. **Transition.** Proceed to `shiplog:branch` if the user wants to start work.
+4. **Transition.** Proceed to `skills/shiplog/branch.md` if the user wants to start work.
 
 ---
 

--- a/skills/shiplog/branch.md
+++ b/skills/shiplog/branch.md
@@ -6,7 +6,7 @@ description: "Phase 2: Create a branch from an issue, set up worktree, and post 
 # Branch Setup (Phase 2)
 
 <!-- routing: tier-2, plan then agent -->
-<!-- cross-cutting: references/model-routing.md (Step 0), SKILL.md §8 (Agent Identity Signing), references/labels.md, references/shell-portability.md, references/orchestrator-protocol.md -->
+<!-- cross-cutting: references/model-routing.md (Step 0), SKILL.md → "Agent Identity Signing", references/labels.md, references/shell-portability.md, references/orchestrator-protocol.md -->
 
 0. **Routing check.** Run the phase entry check from `references/model-routing.md`.
 
@@ -33,7 +33,7 @@ description: "Phase 2: Create a branch from an issue, set up worktree, and post 
    If a delegated lane later uses a forked workspace, tmux session, or other runtime-specific isolation backend, keep this feature branch/worktree as the canonical shiplog record for the work.
    **Fallback (in-place checkout):** Only when the user explicitly requests no worktree.
 
-3. **Post timeline entry.** Comment on the issue using the session-start template below. Record the workspace path when known. Sign per the signing spec — see SKILL.md §8 (Agent Identity Signing).
+3. **Post timeline entry.** Comment on the issue using the session-start template below. Record the workspace path when known. Sign per the signing spec — see SKILL.md → "Agent Identity Signing".
 
 4. **Load plan** if it exists. Delegate to `superpowers:executing-plans` or `ork:implement`.
    For delegated or tier-3 work, the plan should define a contract: allowed files, forbidden changes, stop conditions, verification, return artifact, and decision budget.
@@ -159,6 +159,10 @@ Track the primary feature worktree from session start through cleanup.
 
 Portable cleanup sequence:
 
+> **Canonical source:** this same cleanup sequence is maintained in `references/orchestrator-protocol.md`
+> ("Cleanup commands"), which owns it. Keep both copies in sync when changing it, or replace this copy
+> with a pointer to the canonical block.
+
 ```bash
 git fetch origin
 git branch --merged origin/$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
@@ -180,6 +184,6 @@ git branch -d <branch-name>
 
 ## Edge Cases
 
-**Session resume:** Detect the issue from the current branch name or worktree. If the branch has an existing worktree, `cd` into it. Find linked PRs, read comments, add "Session resumed" timeline comment via `shiplog:timeline`.
+**Session resume:** Detect the issue from the current branch name or worktree. If the branch has an existing worktree, `cd` into it. Find linked PRs, read comments, add "Session resumed" timeline comment via `skills/shiplog/timeline.md`.
 
 **Post-merge cleanup:** If the branch is merged and no open PR still depends on it, run the cleanup protocol above or dispatch a dedicated cleanup lane per `references/orchestrator-protocol.md`.

--- a/skills/shiplog/commit.md
+++ b/skills/shiplog/commit.md
@@ -6,13 +6,13 @@ description: "Phase 4: Commit with conventional format and post context comments
 # Commit Context (Phase 4)
 
 <!-- routing: tier-3, agent -->
-<!-- cross-cutting: references/model-routing.md (Step 0), SKILL.md §8 (Agent Identity Signing), references/verification-profiles.md -->
+<!-- cross-cutting: references/model-routing.md (Step 0), SKILL.md → "Agent Identity Signing", references/verification-profiles.md -->
 
 0. **Routing check.** Run the phase entry check from `references/model-routing.md`.
 
 1. **Create the commit.** Follow `references/commit-workflow.md`. External commit skills may still be used for convenience, but the conventions in the internal workflow take precedence. Format: `<type>(#<issue-id>): <description>`. When a commit addresses a specific task, include the task ID: `<type>(#<issue-id>/<Tn>): <description>`.
 
-2. **Add context comment** for significant commits. Document the reasoning and verification on the issue. Sign per the signing spec — see SKILL.md §8 (Agent Identity Signing).
+2. **Add context comment** for significant commits. Document the reasoning and verification on the issue. Sign per the signing spec — see SKILL.md → "Agent Identity Signing".
 
 **When to add context comments:** After significant functionality, unexpected discoveries, approach changes, or tricky bug fixes. Not after trivial commits.
 

--- a/skills/shiplog/discovery.md
+++ b/skills/shiplog/discovery.md
@@ -6,7 +6,7 @@ description: "Phase 3: Handle mid-work discoveries — fix inline, stack a prere
 # Discovery Handling (Phase 3)
 
 <!-- routing: tier-2, plan then agent -->
-<!-- cross-cutting: references/model-routing.md (Step 0), SKILL.md §8 (Agent Identity Signing), references/labels.md, references/shell-portability.md -->
+<!-- cross-cutting: references/model-routing.md (Step 0), SKILL.md → "Agent Identity Signing", references/labels.md, references/shell-portability.md -->
 
 0. **Routing check.** Run the phase entry check from `references/model-routing.md`.
 
@@ -20,9 +20,9 @@ Discovery made during work
   +-- Refactoring opportunity?             -> Create issue tagged "refactor"
 ```
 
-**3a (stack a prerequisite):** Commit current progress. Create a new issue first (so the ID exists), then create the stacked branch. Label the new issue `shiplog/discovery` and `shiplog/stacked`. Cross-reference on the parent issue and add `shiplog/blocker` to the parent while it is blocked. Sign both artifacts per the signing spec — see SKILL.md §8 (Agent Identity Signing).
+**3a (stack a prerequisite):** Commit current progress. Create a new issue first (so the ID exists), then create the stacked branch. Label the new issue `shiplog/discovery` and `shiplog/stacked`. Cross-reference on the parent issue and add `shiplog/blocker` to the parent while it is blocked. Sign both artifacts per the signing spec — see SKILL.md → "Agent Identity Signing".
 
-**3b (independent discovery):** Create new issue (same template without "blocks parent") and label it `shiplog/discovery`. Add timeline comment. Continue current work. Sign per the signing spec — see SKILL.md §8 (Agent Identity Signing).
+**3b (independent discovery):** Create new issue (same template without "blocks parent") and label it `shiplog/discovery`. Add timeline comment. Continue current work. Sign per the signing spec — see SKILL.md → "Agent Identity Signing".
 
 ---
 

--- a/skills/shiplog/pr.md
+++ b/skills/shiplog/pr.md
@@ -6,19 +6,19 @@ description: "Phase 5: Create PR with timeline body, handle review gate, and lin
 # PR Timeline (Phase 5)
 
 <!-- routing: tier-1, plan -->
-<!-- cross-cutting: references/model-routing.md (Step 0), SKILL.md §8 (Agent Identity Signing), references/closure-and-review.md, references/labels.md, references/orchestrator-protocol.md -->
+<!-- cross-cutting: references/model-routing.md (Step 0), SKILL.md → "Agent Identity Signing", references/closure-and-review.md, references/labels.md, references/orchestrator-protocol.md -->
 
 0. **Routing check.** Run the phase entry check from `references/model-routing.md`.
 
 1. **Pre-PR checks.** Follow `references/pr-workflow.md`. External PR skills may still be used for validation help, but shiplog's internal PR workflow is authoritative for title, body, labels, and review gate behavior.
 
-2. **Create PR (Full Mode).** Use the PR timeline template below. Create the PR with `shiplog/history` and `shiplog/issue-driven` already applied. Sign per the signing spec — see SKILL.md §8 (Agent Identity Signing).
+2. **Create PR (Full Mode).** Use the PR timeline template below. Create the PR with `shiplog/history` and `shiplog/issue-driven` already applied. Sign per the signing spec — see SKILL.md → "Agent Identity Signing".
 
 3. **Review gate.** Every PR requires cross-model review before merge. Use the execution ladder in `references/closure-and-review.md`: bounded reviewer lane if available, then external session delegation, then a contract-only review handoff. Local parallel tool fan-out does not count as an independent reviewer identity.
 
-5. **Link and store.** PR body includes `Closes #<issue>` when the PR fully resolves the issue. For partial delivery, use `Addresses #<issue> (completes T1, T2, ...)` - see the partial-delivery template below and `references/closure-and-review.md` Section 1. Store key learning in knowledge graph.
+4. **Link and store.** PR body includes `Closes #<issue>` when the PR fully resolves the issue. For partial delivery, use `Addresses #<issue> (completes T1, T2, ...)` - see the partial-delivery template below and `references/closure-and-review.md` Section 1. Store key learning in knowledge graph.
 
-6. **Closure verification (optional).** When evidence-to-issue mapping is non-obvious, optionally dispatch a verifier lane using the same orchestration ladder described in `references/closure-and-review.md` and `references/orchestrator-protocol.md`.
+5. **Closure verification (optional).** When evidence-to-issue mapping is non-obvious, optionally dispatch a verifier lane using the same orchestration ladder described in `references/closure-and-review.md` and `references/orchestrator-protocol.md`.
 
 ---
 
@@ -111,7 +111,7 @@ Last-code-by: <family>/<version> (<tool>)
 ```
 
 The PR body is large enough that `--body-file` should be the preferred portable path.
-After every signed review comment and every post-review code push, refresh this review snapshot in place per `references/closure-and-review.md` and the signing spec in SKILL.md §8 (Agent Identity Signing).
+After every signed review comment and every post-review code push, refresh this review snapshot in place per `references/closure-and-review.md` and the signing spec in SKILL.md → "Agent Identity Signing".
 
 If review or cleanup work is dispatched in parallel, post the fan-out dispatch and collection artifacts from `references/orchestrator-protocol.md` instead of leaving that orchestration implicit in chat-only context.
 

--- a/skills/shiplog/references/brainstorm-workflow.md
+++ b/skills/shiplog/references/brainstorm-workflow.md
@@ -68,7 +68,7 @@ Once the design is approved, create a **shiplog** issue using the template in `.
 2. **Context, Design Summary, Approach, Alternatives** — from the brainstorm
 3. **Sources and Verification Status** — for external claims
 4. **Task contracts** — structured `T1`, `T2`, ... with tier annotations, file lists, acceptance criteria, and decision budgets per `../brainstorm.md`
-5. **Provenance signature** — `Authored-by:` per the signing spec — see SKILL.md §8 (Agent Identity Signing)
+5. **Provenance signature** — `Authored-by:` per the signing spec — see SKILL.md → "Agent Identity Signing"
 6. **Label** — `shiplog/plan` applied at creation time
 
 Bootstrap **shiplog** labels first if this is the first labeled create in the repo (see `labels.md`). Use the portable `--body-file` pattern from `shell-portability.md` for the issue body.
@@ -77,7 +77,7 @@ Bootstrap **shiplog** labels first if this is the first labeled create in the re
 
 After issue creation:
 - Store key decisions in the knowledge graph if `ork:remember` is available.
-- Offer to proceed to Phase 2 (branch setup via `shiplog:branch`).
+- Offer to proceed to Phase 2 (branch setup via `skills/shiplog/branch.md`).
 - Do NOT invoke `superpowers:writing-plans` or any implementation skill.
 
 ## Visual Companion

--- a/skills/shiplog/references/closure-and-review.md
+++ b/skills/shiplog/references/closure-and-review.md
@@ -201,7 +201,7 @@ The PR body review snapshot is the latest-wins summary. Read it first for curren
 
 Use the first available signal - each level is less authoritative than the one above:
 
-1. **`Last-code-by:`** in the PR body - authoritative. This field tracks who most recently pushed code to the branch. See SKILL.md §8 (Agent Identity Signing) for code provenance rules.
+1. **`Last-code-by:`** in the PR body - authoritative. This field tracks who most recently pushed code to the branch. See SKILL.md → "Agent Identity Signing" for code provenance rules.
 2. **`Updated-by:`** in the PR body - approximate. May reflect artifact text edits rather than code changes, but is the best proxy when `Last-code-by:` is absent.
 3. **`Authored-by:`** in the PR body - original author. May be stale if another model pushed code later.
 4. **Git commit author** on the PR branch - last resort. Requires an additional API call and uses git metadata rather than signed artifacts, but provides ground truth when no signed field exists.

--- a/skills/shiplog/references/phase-templates.md
+++ b/skills/shiplog/references/phase-templates.md
@@ -30,14 +30,7 @@ Authored-by: <family>/<version> (<tool>)
 Last-code-by: <family>/<version> (<tool>)
 ```
 
-For review sign-off comments:
-
-```
-Reviewed-by: <family>/<version> (<tool>)
-Disposition: approve | approve-with-follow-ups | request-changes
-Scope: <what was reviewed>
-Follow-ups: #<issue-number> | none
-```
+For review sign-off comments, use the four-field block defined in `closure-and-review.md` ("Sign-off format"), which owns it. This file intentionally does not duplicate it.
 
 For in-place edits to existing artifacts (append after the original `Authored-by:` line):
 
@@ -47,4 +40,4 @@ Edit-kind: correction | amendment | rewrite
 Edit-note: [1 sentence describing what changed and why]
 ```
 
-The full signing rules and amendment artifact template live in `../SKILL.md` §8 (Agent Identity Signing).
+The full signing rules and amendment artifact template live in `../SKILL.md` → "Agent Identity Signing".

--- a/skills/shiplog/references/signing.md
+++ b/skills/shiplog/references/signing.md
@@ -1,5 +1,5 @@
 # Agent Identity Signing
 
-> **Moved.** The full provenance signing spec — canonical grammar, role semantics, model detection, orchestration qualifiers, edit provenance rules, code provenance (`Last-code-by:`), edit-in-place vs amendment, and PR body review snapshot maintenance — now lives in **SKILL.md §8 (Agent Identity Signing)**.
+> **Moved.** The full provenance signing spec — canonical grammar, role semantics, model detection, orchestration qualifiers, edit provenance rules, code provenance (`Last-code-by:`), edit-in-place vs amendment, and PR body review snapshot maintenance — now lives in **SKILL.md → "Agent Identity Signing"**.
 >
 > This file is kept as a redirect so that any external links to `references/signing.md` continue to resolve.

--- a/skills/shiplog/timeline.md
+++ b/skills/shiplog/timeline.md
@@ -6,11 +6,11 @@ description: "Phase 7: Add timeline comments for session starts, milestones, dis
 # Timeline Updates (Phase 7)
 
 <!-- routing: tier-3, agent -->
-<!-- cross-cutting: references/model-routing.md (Step 0), SKILL.md §8 (Agent Identity Signing), references/labels.md, references/orchestrator-protocol.md -->
+<!-- cross-cutting: references/model-routing.md (Step 0), SKILL.md → "Agent Identity Signing", references/labels.md, references/orchestrator-protocol.md -->
 
 0. **Routing check.** Run the phase entry check from `references/model-routing.md`.
 
-1. **Add timeline comments** when: starting a new session, changing approach, finding something unexpected, completing a milestone, or getting blocked. Sign per the signing spec — see SKILL.md §8 (Agent Identity Signing).
+1. **Add timeline comments** when: starting a new session, changing approach, finding something unexpected, completing a milestone, or getting blocked. Sign per the signing spec — see SKILL.md → "Agent Identity Signing".
 
 2. **Use the standard format** below. Comment types: `session-start`, `session-resume`, `milestone`, `discovery`, `implementation-issue`, `blocker`.
 


### PR DESCRIPTION
- Replace fragile `SKILL.md §8` citations (19x across 12 files) with a
  name-based reference to the "Agent Identity Signing" section; the
  number had no resolvable anchor in the unnumbered SKILL.md
- SKILL.md: document the commands/ vs skills/ split in the Verb Grid,
  add a Phase Sub-skill Index so phase sub-skill files are reachable
  from the central navigation, and note the two-tree layout in the
  Integration Map (also rename "Sub-skill map" to "Command map")
- skills/shiplog/pr.md: renumber phase steps 5 -> 4 and 6 -> 5 (gap)
- Replace legacy `shiplog:<skill>` references with file paths (4x)
- branch.md: mark the worktree cleanup block with a canonical-source
  note (owned by references/orchestrator-protocol.md)
- phase-templates.md: drop the duplicated review sign-off block and
  point to closure-and-review.md "Sign-off format" (single source)
- SKILL.md golden path: note inline blocks are illustrative; canonical
  templates live in the phase sub-skills
- CONTRIBUTING.md: clarify PR template vs runnable policy file
- Add cross-ref-check workflow rejecting legacy `shiplog:<skill>` refs
- Bump plugin.json version to 0.5.2

Authored-by: moonshot/kimi-k3 (kimi-code)
Reviewed-by: anthropic/claude-opus-4.6